### PR TITLE
feat: add app layout with sidebar and topbar

### DIFF
--- a/src/app/app/_components/sidebar.tsx
+++ b/src/app/app/_components/sidebar.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { cn } from "@/lib/utils";
+import {
+  Home,
+  Users,
+  Building2,
+  Handshake,
+  CheckSquare,
+  BarChart2,
+  Settings,
+} from "lucide-react";
+
+const routes = [
+  { href: "/app", label: "Home", icon: Home },
+  { href: "/app/contacts", label: "Contacts", icon: Users },
+  { href: "/app/companies", label: "Companies", icon: Building2 },
+  { href: "/app/deals", label: "Deals", icon: Handshake },
+  { href: "/app/tasks", label: "Tasks", icon: CheckSquare },
+  { href: "/app/reports", label: "Reports", icon: BarChart2 },
+  { href: "/app/settings", label: "Settings", icon: Settings },
+];
+
+export default function Sidebar() {
+  const pathname = usePathname();
+
+  return (
+    <div className="flex h-full flex-col">
+      <nav className="space-y-1 p-4">
+        {routes.map((route) => {
+          const Icon = route.icon;
+          const active = pathname === route.href;
+          return (
+            <Link
+              key={route.href}
+              href={route.href}
+              className={cn(
+                "flex items-center gap-2 rounded-md px-2 py-1.5 text-sm font-medium hover:bg-accent hover:text-accent-foreground",
+                active && "bg-accent text-accent-foreground"
+              )}
+            >
+              <Icon className="h-4 w-4" />
+              {route.label}
+            </Link>
+          );
+        })}
+      </nav>
+    </div>
+  );
+}

--- a/src/app/app/_components/topbar.tsx
+++ b/src/app/app/_components/topbar.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { Menu } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Sheet,
+  SheetTrigger,
+  SheetContent,
+} from "@/components/ui/sheet";
+import Sidebar from "./sidebar";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@/components/ui/dropdown-menu";
+
+export default function Topbar() {
+  return (
+    <div className="flex h-14 items-center justify-between border-b px-4">
+      <Sheet>
+        <SheetTrigger asChild>
+          <Button variant="ghost" size="icon" className="md:hidden">
+            <Menu className="h-5 w-5" />
+            <span className="sr-only">Toggle menu</span>
+          </Button>
+        </SheetTrigger>
+        <SheetContent side="left" className="p-0 w-64">
+          <Sidebar />
+        </SheetContent>
+      </Sheet>
+      <div className="flex items-center gap-2">
+        <OrgSwitcher />
+        <UserNav />
+      </div>
+    </div>
+  );
+}
+
+function OrgSwitcher() {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="sm">
+          Acme Inc
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem>Acme Inc</DropdownMenuItem>
+        <DropdownMenuItem>Globex</DropdownMenuItem>
+        <DropdownMenuItem>Umbrella</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function UserNav() {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="sm">
+          User
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem>Profile</DropdownMenuItem>
+        <DropdownMenuItem>Logout</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/app/app/companies/page.tsx
+++ b/src/app/app/companies/page.tsx
@@ -1,0 +1,3 @@
+export default function CompaniesPage() {
+  return <div className="p-4">Companies Page</div>;
+}

--- a/src/app/app/contacts/page.tsx
+++ b/src/app/app/contacts/page.tsx
@@ -1,0 +1,3 @@
+export default function ContactsPage() {
+  return <div className="p-4">Contacts Page</div>;
+}

--- a/src/app/app/deals/page.tsx
+++ b/src/app/app/deals/page.tsx
@@ -1,0 +1,3 @@
+export default function DealsPage() {
+  return <div className="p-4">Deals Page</div>;
+}

--- a/src/app/app/layout.tsx
+++ b/src/app/app/layout.tsx
@@ -1,0 +1,17 @@
+import { ReactNode } from "react";
+import Sidebar from "./_components/sidebar";
+import Topbar from "./_components/topbar";
+
+export default function AppLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex min-h-screen">
+      <aside className="hidden w-64 border-r md:flex">
+        <Sidebar />
+      </aside>
+      <div className="flex flex-1 flex-col">
+        <Topbar />
+        <main className="flex-1 p-4">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/src/app/app/reports/page.tsx
+++ b/src/app/app/reports/page.tsx
@@ -1,0 +1,3 @@
+export default function ReportsPage() {
+  return <div className="p-4">Reports Page</div>;
+}

--- a/src/app/app/settings/page.tsx
+++ b/src/app/app/settings/page.tsx
@@ -1,0 +1,3 @@
+export default function SettingsPage() {
+  return <div className="p-4">Settings Page</div>;
+}

--- a/src/app/app/tasks/page.tsx
+++ b/src/app/app/tasks/page.tsx
@@ -1,0 +1,3 @@
+export default function TasksPage() {
+  return <div className="p-4">Tasks Page</div>;
+}


### PR DESCRIPTION
## Summary
- scaffold /app layout with sidebar and topbar navigation
- add placeholder pages for app routes

## Testing
- `npm test`
- `npm run lint` *(fails: next not found)*
- `npm install` *(fails: 403 Forbidden fetching @auth/prisma-adapter)*

------
https://chatgpt.com/codex/tasks/task_e_68c4508eb3c48330acbf40dc21c30839