### PR TITLE
feat: add CRM schemas and API routes

### DIFF
--- a/src/app/api/activities/[id]/route.ts
+++ b/src/app/api/activities/[id]/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireRole } from "@/lib/auth";
+import { activitySchema } from "@/lib/validators";
+import { handleApiError } from "@/lib/api";
+import { MembershipRole } from "@prisma/client";
+
+interface Params {
+  params: { id: string };
+}
+
+export async function PATCH(req: Request, { params }: Params) {
+  try {
+    const { membership } = await requireRole(
+      MembershipRole.REP,
+      MembershipRole.ADMIN,
+      MembershipRole.OWNER
+    );
+    const existing = await prisma.activity.findFirst({
+      where: { id: params.id, organizationId: membership.organizationId },
+    });
+    if (!existing) return new Response("Not Found", { status: 404 });
+    const data = activitySchema.partial().parse(await req.json());
+    const activity = await prisma.activity.update({
+      where: { id: params.id },
+      data,
+    });
+    return NextResponse.json(activity);
+  } catch (e) {
+    return handleApiError(e);
+  }
+}
+
+export async function DELETE(_req: Request, { params }: Params) {
+  try {
+    const { membership } = await requireRole(
+      MembershipRole.REP,
+      MembershipRole.ADMIN,
+      MembershipRole.OWNER
+    );
+    const existing = await prisma.activity.findFirst({
+      where: { id: params.id, organizationId: membership.organizationId },
+    });
+    if (!existing) return new Response("Not Found", { status: 404 });
+    await prisma.activity.delete({ where: { id: params.id } });
+    return new Response(null, { status: 204 });
+  } catch (e) {
+    return handleApiError(e);
+  }
+}
+

--- a/src/app/api/activities/route.ts
+++ b/src/app/api/activities/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireRole } from "@/lib/auth";
+import { activitySchema } from "@/lib/validators";
+import { handleApiError } from "@/lib/api";
+import { MembershipRole, ActivityType } from "@prisma/client";
+
+export async function GET(req: Request) {
+  try {
+    const { membership } = await requireRole(
+      MembershipRole.REP,
+      MembershipRole.ADMIN,
+      MembershipRole.OWNER
+    );
+    const { searchParams } = new URL(req.url);
+    const type = searchParams.get("type") as ActivityType | null;
+    const activities = await prisma.activity.findMany({
+      where: {
+        organizationId: membership.organizationId,
+        ...(type ? { type } : {}),
+      },
+    });
+    return NextResponse.json(activities);
+  } catch (e) {
+    return handleApiError(e);
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const { membership, user } = await requireRole(
+      MembershipRole.REP,
+      MembershipRole.ADMIN,
+      MembershipRole.OWNER
+    );
+    const data = activitySchema.parse(await req.json());
+    const activity = await prisma.activity.create({
+      data: {
+        ...data,
+        organizationId: membership.organizationId,
+        ownerId: user.id,
+      },
+    });
+    return NextResponse.json(activity, { status: 201 });
+  } catch (e) {
+    return handleApiError(e);
+  }
+}
+

--- a/src/app/api/companies/[id]/route.ts
+++ b/src/app/api/companies/[id]/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireRole } from "@/lib/auth";
+import { companySchema } from "@/lib/validators";
+import { handleApiError } from "@/lib/api";
+import { MembershipRole } from "@prisma/client";
+
+interface Params {
+  params: { id: string };
+}
+
+export async function PATCH(req: Request, { params }: Params) {
+  try {
+    const { membership } = await requireRole(
+      MembershipRole.ADMIN,
+      MembershipRole.OWNER
+    );
+    const existing = await prisma.company.findFirst({
+      where: { id: params.id, organizationId: membership.organizationId },
+    });
+    if (!existing) return new Response("Not Found", { status: 404 });
+    const data = companySchema.partial().parse(await req.json());
+    const company = await prisma.company.update({
+      where: { id: params.id },
+      data,
+    });
+    return NextResponse.json(company);
+  } catch (e) {
+    return handleApiError(e);
+  }
+}
+
+export async function DELETE(_req: Request, { params }: Params) {
+  try {
+    const { membership } = await requireRole(
+      MembershipRole.ADMIN,
+      MembershipRole.OWNER
+    );
+    const existing = await prisma.company.findFirst({
+      where: { id: params.id, organizationId: membership.organizationId },
+    });
+    if (!existing) return new Response("Not Found", { status: 404 });
+    await prisma.company.delete({ where: { id: params.id } });
+    return new Response(null, { status: 204 });
+  } catch (e) {
+    return handleApiError(e);
+  }
+}
+

--- a/src/app/api/companies/route.ts
+++ b/src/app/api/companies/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireRole } from "@/lib/auth";
+import { companySchema } from "@/lib/validators";
+import { handleApiError } from "@/lib/api";
+import { MembershipRole } from "@prisma/client";
+
+// GET list of companies & POST create new company
+export async function GET(req: Request) {
+  try {
+    const { membership } = await requireRole(
+      MembershipRole.REP,
+      MembershipRole.ADMIN,
+      MembershipRole.OWNER
+    );
+    const { searchParams } = new URL(req.url);
+    const q = searchParams.get("q") ?? undefined;
+    const companies = await prisma.company.findMany({
+      where: {
+        organizationId: membership.organizationId,
+        ...(q ? { name: { contains: q, mode: "insensitive" } } : {}),
+      },
+    });
+    return NextResponse.json(companies);
+  } catch (e) {
+    return handleApiError(e);
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const { membership, user } = await requireRole(
+      MembershipRole.ADMIN,
+      MembershipRole.OWNER
+    );
+    const data = companySchema.parse(await req.json());
+    const company = await prisma.company.create({
+      data: {
+        ...data,
+        organizationId: membership.organizationId,
+        ownerId: user.id,
+      },
+    });
+    return NextResponse.json(company, { status: 201 });
+  } catch (e) {
+    return handleApiError(e);
+  }
+}
+

--- a/src/app/api/contacts/[id]/route.ts
+++ b/src/app/api/contacts/[id]/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireRole } from "@/lib/auth";
+import { contactSchema } from "@/lib/validators";
+import { handleApiError } from "@/lib/api";
+import { MembershipRole } from "@prisma/client";
+
+interface Params {
+  params: { id: string };
+}
+
+export async function PATCH(req: Request, { params }: Params) {
+  try {
+    const { membership } = await requireRole(
+      MembershipRole.REP,
+      MembershipRole.ADMIN,
+      MembershipRole.OWNER
+    );
+    const existing = await prisma.contact.findFirst({
+      where: { id: params.id, organizationId: membership.organizationId },
+    });
+    if (!existing) return new Response("Not Found", { status: 404 });
+    const data = contactSchema.partial().parse(await req.json());
+    const contact = await prisma.contact.update({
+      where: { id: params.id },
+      data,
+    });
+    return NextResponse.json(contact);
+  } catch (e) {
+    return handleApiError(e);
+  }
+}
+
+export async function DELETE(_req: Request, { params }: Params) {
+  try {
+    const { membership } = await requireRole(
+      MembershipRole.ADMIN,
+      MembershipRole.OWNER
+    );
+    const existing = await prisma.contact.findFirst({
+      where: { id: params.id, organizationId: membership.organizationId },
+    });
+    if (!existing) return new Response("Not Found", { status: 404 });
+    await prisma.contact.delete({ where: { id: params.id } });
+    return new Response(null, { status: 204 });
+  } catch (e) {
+    return handleApiError(e);
+  }
+}
+

--- a/src/app/api/contacts/route.ts
+++ b/src/app/api/contacts/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireRole } from "@/lib/auth";
+import { contactSchema } from "@/lib/validators";
+import { handleApiError } from "@/lib/api";
+import { MembershipRole } from "@prisma/client";
+
+export async function GET(req: Request) {
+  try {
+    const { membership } = await requireRole(
+      MembershipRole.REP,
+      MembershipRole.ADMIN,
+      MembershipRole.OWNER
+    );
+    const { searchParams } = new URL(req.url);
+    const q = searchParams.get("q") ?? undefined;
+    const contacts = await prisma.contact.findMany({
+      where: {
+        organizationId: membership.organizationId,
+        ...(q
+          ? {
+              OR: [
+                { firstName: { contains: q, mode: "insensitive" } },
+                { lastName: { contains: q, mode: "insensitive" } },
+              ],
+            }
+          : {}),
+      },
+    });
+    return NextResponse.json(contacts);
+  } catch (e) {
+    return handleApiError(e);
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const { membership, user } = await requireRole(
+      MembershipRole.REP,
+      MembershipRole.ADMIN,
+      MembershipRole.OWNER
+    );
+    const data = contactSchema.parse(await req.json());
+    const contact = await prisma.contact.create({
+      data: {
+        ...data,
+        organizationId: membership.organizationId,
+        ownerId: user.id,
+      },
+    });
+    return NextResponse.json(contact, { status: 201 });
+  } catch (e) {
+    return handleApiError(e);
+  }
+}
+

--- a/src/app/api/deals/[id]/route.ts
+++ b/src/app/api/deals/[id]/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireRole } from "@/lib/auth";
+import { dealSchema } from "@/lib/validators";
+import { handleApiError } from "@/lib/api";
+import { MembershipRole } from "@prisma/client";
+
+interface Params {
+  params: { id: string };
+}
+
+export async function PATCH(req: Request, { params }: Params) {
+  try {
+    const { membership } = await requireRole(
+      MembershipRole.REP,
+      MembershipRole.ADMIN,
+      MembershipRole.OWNER
+    );
+    const existing = await prisma.deal.findFirst({
+      where: { id: params.id, organizationId: membership.organizationId },
+    });
+    if (!existing) return new Response("Not Found", { status: 404 });
+    const data = dealSchema.partial().parse(await req.json());
+    const deal = await prisma.deal.update({
+      where: { id: params.id },
+      data,
+    });
+    return NextResponse.json(deal);
+  } catch (e) {
+    return handleApiError(e);
+  }
+}
+
+export async function DELETE(_req: Request, { params }: Params) {
+  try {
+    const { membership } = await requireRole(
+      MembershipRole.ADMIN,
+      MembershipRole.OWNER
+    );
+    const existing = await prisma.deal.findFirst({
+      where: { id: params.id, organizationId: membership.organizationId },
+    });
+    if (!existing) return new Response("Not Found", { status: 404 });
+    await prisma.deal.delete({ where: { id: params.id } });
+    return new Response(null, { status: 204 });
+  } catch (e) {
+    return handleApiError(e);
+  }
+}
+

--- a/src/app/api/deals/route.ts
+++ b/src/app/api/deals/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireRole } from "@/lib/auth";
+import { dealSchema } from "@/lib/validators";
+import { handleApiError } from "@/lib/api";
+import { MembershipRole, DealStatus } from "@prisma/client";
+
+export async function GET(req: Request) {
+  try {
+    const { membership } = await requireRole(
+      MembershipRole.REP,
+      MembershipRole.ADMIN,
+      MembershipRole.OWNER
+    );
+    const { searchParams } = new URL(req.url);
+    const status = searchParams.get("status") as DealStatus | null;
+    const deals = await prisma.deal.findMany({
+      where: {
+        organizationId: membership.organizationId,
+        ...(status ? { status } : {}),
+      },
+    });
+    return NextResponse.json(deals);
+  } catch (e) {
+    return handleApiError(e);
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const { membership, user } = await requireRole(
+      MembershipRole.REP,
+      MembershipRole.ADMIN,
+      MembershipRole.OWNER
+    );
+    const data = dealSchema.parse(await req.json());
+    const deal = await prisma.deal.create({
+      data: {
+        ...data,
+        organizationId: membership.organizationId,
+        ownerId: user.id,
+      },
+    });
+    return NextResponse.json(deal, { status: 201 });
+  } catch (e) {
+    return handleApiError(e);
+  }
+}
+

--- a/src/app/api/notes/[id]/route.ts
+++ b/src/app/api/notes/[id]/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireRole } from "@/lib/auth";
+import { noteSchema } from "@/lib/validators";
+import { handleApiError } from "@/lib/api";
+import { MembershipRole } from "@prisma/client";
+
+interface Params {
+  params: { id: string };
+}
+
+export async function PATCH(req: Request, { params }: Params) {
+  try {
+    const { membership } = await requireRole(
+      MembershipRole.REP,
+      MembershipRole.ADMIN,
+      MembershipRole.OWNER
+    );
+    const existing = await prisma.note.findFirst({
+      where: { id: params.id, organizationId: membership.organizationId },
+    });
+    if (!existing) return new Response("Not Found", { status: 404 });
+    const data = noteSchema.partial().parse(await req.json());
+    const note = await prisma.note.update({
+      where: { id: params.id },
+      data,
+    });
+    return NextResponse.json(note);
+  } catch (e) {
+    return handleApiError(e);
+  }
+}
+
+export async function DELETE(_req: Request, { params }: Params) {
+  try {
+    const { membership } = await requireRole(
+      MembershipRole.REP,
+      MembershipRole.ADMIN,
+      MembershipRole.OWNER
+    );
+    const existing = await prisma.note.findFirst({
+      where: { id: params.id, organizationId: membership.organizationId },
+    });
+    if (!existing) return new Response("Not Found", { status: 404 });
+    await prisma.note.delete({ where: { id: params.id } });
+    return new Response(null, { status: 204 });
+  } catch (e) {
+    return handleApiError(e);
+  }
+}
+

--- a/src/app/api/notes/route.ts
+++ b/src/app/api/notes/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireRole } from "@/lib/auth";
+import { noteSchema } from "@/lib/validators";
+import { handleApiError } from "@/lib/api";
+import { MembershipRole } from "@prisma/client";
+
+export async function GET(req: Request) {
+  try {
+    const { membership } = await requireRole(
+      MembershipRole.REP,
+      MembershipRole.ADMIN,
+      MembershipRole.OWNER
+    );
+    const { searchParams } = new URL(req.url);
+    const dealId = searchParams.get("dealId") ?? undefined;
+    const contactId = searchParams.get("contactId") ?? undefined;
+    const notes = await prisma.note.findMany({
+      where: {
+        organizationId: membership.organizationId,
+        ...(dealId ? { dealId } : {}),
+        ...(contactId ? { contactId } : {}),
+      },
+    });
+    return NextResponse.json(notes);
+  } catch (e) {
+    return handleApiError(e);
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const { membership, user } = await requireRole(
+      MembershipRole.REP,
+      MembershipRole.ADMIN,
+      MembershipRole.OWNER
+    );
+    const data = noteSchema.parse(await req.json());
+    const note = await prisma.note.create({
+      data: {
+        ...data,
+        organizationId: membership.organizationId,
+        authorId: user.id,
+      },
+    });
+    return NextResponse.json(note, { status: 201 });
+  } catch (e) {
+    return handleApiError(e);
+  }
+}
+

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,24 @@
+import { ZodError } from "zod";
+
+/**
+ * Helper to convert thrown errors from route handlers into
+ * proper HTTP responses. Ensures consistent 401/403/422 codes
+ * as required by the specification.
+ */
+export function handleApiError(error: any): Response {
+  if (error?.message === "Unauthorized") {
+    return new Response("Unauthorized", { status: 401 });
+  }
+  if (error?.message === "Forbidden") {
+    return new Response("Forbidden", { status: 403 });
+  }
+  if (error instanceof ZodError) {
+    return new Response(JSON.stringify({ issues: error.issues }), {
+      status: 422,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+  console.error(error);
+  return new Response("Internal Server Error", { status: 500 });
+}
+

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -1,0 +1,67 @@
+import { z } from "zod";
+import { ActivityType, DealStatus } from "@prisma/client";
+
+/**
+ * Central zod schemas used to validate and sanitize
+ * incoming data for core CRM entities. These schemas
+ * intentionally mirror the Prisma models but only expose
+ * the fields that can be set through the API.
+ */
+
+export const companySchema = z.object({
+  name: z.string().trim().min(1),
+  domain: z.string().trim().optional(),
+  phone: z.string().trim().optional(),
+  website: z.string().trim().optional(),
+});
+
+export const contactSchema = z.object({
+  companyId: z.string().cuid().optional(),
+  firstName: z.string().trim().min(1),
+  lastName: z.string().trim().min(1),
+  email: z.string().trim().email().optional(),
+  phone: z.string().trim().optional(),
+});
+
+export const dealSchema = z.object({
+  companyId: z.string().cuid().optional(),
+  contactId: z.string().cuid().optional(),
+  pipelineId: z.string().cuid(),
+  stageId: z.string().cuid(),
+  title: z.string().trim().min(1),
+  valueCents: z.number().int().nonnegative(),
+  currency: z.string().trim().length(3),
+  status: z.nativeEnum(DealStatus).default(DealStatus.OPEN),
+  closeDate: z.coerce.date().optional(),
+});
+
+export const activitySchema = z.object({
+  dealId: z.string().cuid().optional(),
+  contactId: z.string().cuid().optional(),
+  type: z.nativeEnum(ActivityType),
+  title: z.string().trim().min(1),
+  note: z.string().trim().optional(),
+  dueAt: z.coerce.date().optional(),
+  completedAt: z.coerce.date().optional(),
+});
+
+export const noteSchema = z.object({
+  dealId: z.string().cuid().optional(),
+  contactId: z.string().cuid().optional(),
+  body: z.string().trim().min(1),
+});
+
+export const tagSchema = z.object({
+  name: z.string().trim().min(1),
+});
+
+export const pipelineSchema = z.object({
+  name: z.string().trim().min(1),
+});
+
+export const stageSchema = z.object({
+  pipelineId: z.string().cuid(),
+  name: z.string().trim().min(1),
+  order: z.number().int().nonnegative(),
+});
+


### PR DESCRIPTION
## Summary
- add centralized Zod schemas for CRM models
- implement CRUD route handlers with org scoping and RBAC
- add API error handler for uniform 401/403/422 responses

## Testing
- `npm test`
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@auth%2fprisma-adapter)*

------
https://chatgpt.com/codex/tasks/task_e_68c452f7fcf8833082043b1f90b6a696