### PR TITLE
feat: add contacts and companies management

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react-hook-form": "^7.48.0",
     "recharts": "^2.7.2",
     "zod": "^3.22.4",
+    "papaparse": "^5.4.1",
     "@radix-ui/react-dialog": "^1.0.0",
     "@radix-ui/react-dropdown-menu": "^2.0.0",
     "@radix-ui/react-label": "^2.0.0",

--- a/src/app/app/companies/[id]/page.tsx
+++ b/src/app/app/companies/[id]/page.tsx
@@ -1,0 +1,53 @@
+import { prisma } from '@/lib/prisma';
+
+interface Params {
+  params: { id: string };
+}
+
+export default async function CompanyDetailPage({ params }: Params) {
+  const company = await prisma.company.findUnique({
+    where: { id: params.id },
+    include: { contacts: true, deals: true },
+  });
+  if (!company) {
+    return <div className="p-4">Company not found</div>;
+  }
+  return (
+    <div className="p-4 space-y-8">
+      <section>
+        <h2 className="text-xl font-semibold">Summary</h2>
+        <div>Name: {company.name}</div>
+        {company.domain && <div>Domain: {company.domain}</div>}
+        {company.phone && <div>Phone: {company.phone}</div>}
+        {company.website && <div>Website: {company.website}</div>}
+      </section>
+      <section>
+        <h2 className="text-xl font-semibold">Contacts</h2>
+        <ul className="list-disc ml-6">
+          {company.contacts.map((c) => (
+            <li key={c.id}>
+              {c.firstName} {c.lastName}
+            </li>
+          ))}
+        </ul>
+      </section>
+      <section>
+        <h2 className="text-xl font-semibold">Deals</h2>
+        <ul className="list-disc ml-6">
+          {company.deals.map((d) => (
+            <li key={d.id}>{d.title}</li>
+          ))}
+        </ul>
+      </section>
+      <section>
+        <h2 className="text-xl font-semibold">Notes</h2>
+        <p>No notes yet.</p>
+      </section>
+      <section>
+        <h2 className="text-xl font-semibold">Files</h2>
+        <p>No files yet.</p>
+      </section>
+    </div>
+  );
+}
+

--- a/src/app/app/companies/companies-table.tsx
+++ b/src/app/app/companies/companies-table.tsx
@@ -1,0 +1,216 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from '@tanstack/react-table';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import CompanyForm from './company-form';
+import Link from 'next/link';
+
+interface Company {
+  id: string;
+  name: string;
+  domain?: string | null;
+  phone?: string | null;
+  website?: string | null;
+}
+
+export default function CompaniesTable() {
+  const [data, setData] = useState<Company[]>([]);
+  const [sorting, setSorting] = useState<any[]>([]);
+  const [columnVisibility, setColumnVisibility] = useState({});
+  const [globalFilter, setGlobalFilter] = useState('');
+  const [formOpen, setFormOpen] = useState(false);
+  const [editing, setEditing] = useState<Company | undefined>(undefined);
+
+  const columns = useMemo<ColumnDef<Company>[]>(
+    () => [
+      {
+        accessorKey: 'name',
+        header: 'Name',
+        cell: ({ row }) => (
+          <Link href={`/app/companies/${row.original.id}`} className="underline">
+            {row.original.name}
+          </Link>
+        ),
+      },
+      { accessorKey: 'domain', header: 'Domain' },
+      { accessorKey: 'phone', header: 'Phone' },
+      { accessorKey: 'website', header: 'Website' },
+      {
+        id: 'actions',
+        header: '',
+        cell: ({ row }) => (
+          <div className="flex gap-2 justify-end">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                setEditing(row.original);
+                setFormOpen(true);
+              }}
+            >
+              Edit
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => deleteCompany(row.original.id)}
+            >
+              Delete
+            </Button>
+          </div>
+        ),
+      },
+    ],
+    []
+  );
+
+  const table = useReactTable({
+    data,
+    columns,
+    state: { sorting, columnVisibility, globalFilter },
+    onSortingChange: setSorting,
+    onColumnVisibilityChange: setColumnVisibility,
+    onGlobalFilterChange: setGlobalFilter,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+  });
+
+  const fetchCompanies = async (q?: string) => {
+    const res = await fetch('/api/companies' + (q ? `?q=${encodeURIComponent(q)}` : ''));
+    if (res.ok) {
+      setData(await res.json());
+    }
+  };
+
+  useEffect(() => {
+    fetchCompanies(globalFilter);
+  }, [globalFilter]);
+
+  const deleteCompany = async (id: string) => {
+    await fetch(`/api/companies/${id}`, { method: 'DELETE' });
+    fetchCompanies(globalFilter);
+  };
+
+  const startCreate = () => {
+    setEditing(undefined);
+    setFormOpen(true);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-2">
+        <Input
+          placeholder="Search..."
+          value={globalFilter}
+          onChange={(e) => setGlobalFilter(e.target.value)}
+          className="max-w-sm"
+        />
+        <div className="flex gap-2">
+          <Button onClick={startCreate}>Add Company</Button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline">Columns</Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              {table.getAllLeafColumns().map((column) => (
+                <DropdownMenuCheckboxItem
+                  key={column.id}
+                  className="capitalize"
+                  checked={column.getIsVisible()}
+                  onCheckedChange={(value) => column.toggleVisibility(!!value)}
+                >
+                  {column.id}
+                </DropdownMenuCheckboxItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </div>
+      <Table>
+        <TableHeader>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <TableRow key={headerGroup.id}>
+              {headerGroup.headers.map((header) => (
+                <TableHead key={header.id} colSpan={header.colSpan}>
+                  {header.isPlaceholder ? null : (
+                    <div
+                      className={header.column.getCanSort() ? 'cursor-pointer select-none' : ''}
+                      onClick={header.column.getToggleSortingHandler()}
+                    >
+                      {flexRender(header.column.columnDef.header, header.getContext())}
+                      {{ asc: ' \u25B2', desc: ' \u25BC' }[
+                        header.column.getIsSorted() as string
+                      ] ?? null}
+                    </div>
+                  )}
+                </TableHead>
+              ))}
+            </TableRow>
+          ))}
+        </TableHeader>
+        <TableBody>
+          {table.getRowModel().rows.map((row) => (
+            <TableRow key={row.id}>
+              {row.getVisibleCells().map((cell) => (
+                <TableCell key={cell.id}>
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+      <div className="flex items-center justify-end gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => table.previousPage()}
+          disabled={!table.getCanPreviousPage()}
+        >
+          Previous
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => table.nextPage()}
+          disabled={!table.getCanNextPage()}
+        >
+          Next
+        </Button>
+      </div>
+      <CompanyForm
+        open={formOpen}
+        onOpenChange={setFormOpen}
+        initialData={editing}
+        onSaved={() => fetchCompanies(globalFilter)}
+      />
+    </div>
+  );
+}
+

--- a/src/app/app/companies/company-form.tsx
+++ b/src/app/app/companies/company-form.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { useState } from 'react';
+import { z } from 'zod';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { companySchema } from '@/lib/validators';
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+
+type CompanyFormValues = z.infer<typeof companySchema>;
+
+interface CompanyFormProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  initialData?: { id: string } & CompanyFormValues;
+  onSaved?: () => void;
+}
+
+export default function CompanyForm({ open, onOpenChange, initialData, onSaved }: CompanyFormProps) {
+  const form = useForm<CompanyFormValues>({
+    resolver: zodResolver(companySchema),
+    defaultValues: initialData ?? {
+      name: '',
+      domain: '',
+      phone: '',
+      website: '',
+    },
+  });
+
+  const [saving, setSaving] = useState(false);
+
+  const onSubmit = async (values: CompanyFormValues) => {
+    setSaving(true);
+    const res = await fetch(initialData ? `/api/companies/${initialData.id}` : '/api/companies', {
+      method: initialData ? 'PATCH' : 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(values),
+    });
+    setSaving(false);
+    if (res.ok) {
+      onOpenChange(false);
+      form.reset();
+      onSaved?.();
+    }
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="space-y-4">
+        <SheetHeader>
+          <SheetTitle>{initialData ? 'Edit Company' : 'New Company'}</SheetTitle>
+        </SheetHeader>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="name">Name</Label>
+            <Input id="name" {...form.register('name')} />
+            {form.formState.errors.name && (
+              <p className="text-sm text-red-500">{form.formState.errors.name.message}</p>
+            )}
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="domain">Domain</Label>
+            <Input id="domain" {...form.register('domain')} />
+            {form.formState.errors.domain && (
+              <p className="text-sm text-red-500">{form.formState.errors.domain.message}</p>
+            )}
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="phone">Phone</Label>
+            <Input id="phone" {...form.register('phone')} />
+            {form.formState.errors.phone && (
+              <p className="text-sm text-red-500">{form.formState.errors.phone.message}</p>
+            )}
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="website">Website</Label>
+            <Input id="website" {...form.register('website')} />
+            {form.formState.errors.website && (
+              <p className="text-sm text-red-500">{form.formState.errors.website.message}</p>
+            )}
+          </div>
+          <Button type="submit" disabled={saving}>
+            {saving ? 'Saving...' : 'Save'}
+          </Button>
+        </form>
+      </SheetContent>
+    </Sheet>
+  );
+}
+

--- a/src/app/app/companies/page.tsx
+++ b/src/app/app/companies/page.tsx
@@ -1,3 +1,9 @@
+import CompaniesTable from './companies-table';
+
 export default function CompaniesPage() {
-  return <div className="p-4">Companies Page</div>;
+  return (
+    <div className="p-4">
+      <CompaniesTable />
+    </div>
+  );
 }

--- a/src/app/app/contacts/contact-form.tsx
+++ b/src/app/app/contacts/contact-form.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { useState } from 'react';
+import { z } from 'zod';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { contactSchema } from '@/lib/validators';
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+
+type ContactFormValues = z.infer<typeof contactSchema>;
+
+interface ContactFormProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  initialData?: { id: string } & ContactFormValues;
+  onSaved?: () => void;
+}
+
+export default function ContactForm({ open, onOpenChange, initialData, onSaved }: ContactFormProps) {
+  const form = useForm<ContactFormValues>({
+    resolver: zodResolver(contactSchema),
+    defaultValues: initialData ?? {
+      firstName: '',
+      lastName: '',
+      email: '',
+      phone: '',
+    },
+  });
+
+  const [saving, setSaving] = useState(false);
+
+  const onSubmit = async (values: ContactFormValues) => {
+    setSaving(true);
+    const res = await fetch(initialData ? `/api/contacts/${initialData.id}` : '/api/contacts', {
+      method: initialData ? 'PATCH' : 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(values),
+    });
+    setSaving(false);
+    if (res.ok) {
+      onOpenChange(false);
+      form.reset();
+      onSaved?.();
+    }
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="space-y-4">
+        <SheetHeader>
+          <SheetTitle>{initialData ? 'Edit Contact' : 'New Contact'}</SheetTitle>
+        </SheetHeader>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="firstName">First Name</Label>
+            <Input id="firstName" {...form.register('firstName')} />
+            {form.formState.errors.firstName && (
+              <p className="text-sm text-red-500">{form.formState.errors.firstName.message}</p>
+            )}
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="lastName">Last Name</Label>
+            <Input id="lastName" {...form.register('lastName')} />
+            {form.formState.errors.lastName && (
+              <p className="text-sm text-red-500">{form.formState.errors.lastName.message}</p>
+            )}
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="email">Email</Label>
+            <Input id="email" type="email" {...form.register('email')} />
+            {form.formState.errors.email && (
+              <p className="text-sm text-red-500">{form.formState.errors.email.message}</p>
+            )}
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="phone">Phone</Label>
+            <Input id="phone" {...form.register('phone')} />
+            {form.formState.errors.phone && (
+              <p className="text-sm text-red-500">{form.formState.errors.phone.message}</p>
+            )}
+          </div>
+          <Button type="submit" disabled={saving}>
+            {saving ? 'Saving...' : 'Save'}
+          </Button>
+        </form>
+      </SheetContent>
+    </Sheet>
+  );
+}
+

--- a/src/app/app/contacts/contacts-table.tsx
+++ b/src/app/app/contacts/contacts-table.tsx
@@ -1,0 +1,280 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from '@tanstack/react-table';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import ContactForm from './contact-form';
+import Papa from 'papaparse';
+import { contactSchema } from '@/lib/validators';
+import { z } from 'zod';
+
+interface Contact {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email?: string | null;
+  phone?: string | null;
+}
+
+const batchSize = 10;
+
+export default function ContactsTable() {
+  const [data, setData] = useState<Contact[]>([]);
+  const [sorting, setSorting] = useState<any[]>([]);
+  const [columnVisibility, setColumnVisibility] = useState({});
+  const [globalFilter, setGlobalFilter] = useState('');
+  const [formOpen, setFormOpen] = useState(false);
+  const [editing, setEditing] = useState<Contact | undefined>(undefined);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [importErrors, setImportErrors] = useState<string[]>([]);
+
+  const columns = useMemo<ColumnDef<Contact>[]>(
+    () => [
+      {
+        accessorKey: 'firstName',
+        header: 'First Name',
+      },
+      {
+        accessorKey: 'lastName',
+        header: 'Last Name',
+      },
+      {
+        accessorKey: 'email',
+        header: 'Email',
+      },
+      {
+        accessorKey: 'phone',
+        header: 'Phone',
+      },
+      {
+        id: 'actions',
+        header: '',
+        cell: ({ row }) => (
+          <div className="flex gap-2 justify-end">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                setEditing(row.original);
+                setFormOpen(true);
+              }}
+            >
+              Edit
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => deleteContact(row.original.id)}
+            >
+              Delete
+            </Button>
+          </div>
+        ),
+      },
+    ],
+    []
+  );
+
+  const table = useReactTable({
+    data,
+    columns,
+    state: { sorting, columnVisibility, globalFilter },
+    onSortingChange: setSorting,
+    onColumnVisibilityChange: setColumnVisibility,
+    onGlobalFilterChange: setGlobalFilter,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+  });
+
+  const fetchContacts = async (q?: string) => {
+    const res = await fetch('/api/contacts' + (q ? `?q=${encodeURIComponent(q)}` : ''));
+    if (res.ok) {
+      const json = await res.json();
+      setData(json);
+    }
+  };
+
+  useEffect(() => {
+    fetchContacts(globalFilter);
+  }, [globalFilter]);
+
+  const deleteContact = async (id: string) => {
+    await fetch(`/api/contacts/${id}`, { method: 'DELETE' });
+    fetchContacts(globalFilter);
+  };
+
+  const startCreate = () => {
+    setEditing(undefined);
+    setFormOpen(true);
+  };
+
+  const handleImport = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setImportErrors([]);
+    Papa.parse<Record<string, string>>(file, {
+      header: true,
+      skipEmptyLines: true,
+      complete: async (results) => {
+        const valid: z.infer<typeof contactSchema>[] = [];
+        const errors: string[] = [];
+        results.data.forEach((row, i) => {
+          const parsed = contactSchema.safeParse(row);
+          if (parsed.success) {
+            valid.push(parsed.data);
+          } else {
+            errors.push(`Row ${i + 2}: ${parsed.error.issues.map((iss) => iss.message).join(', ')}`);
+          }
+        });
+        setImportErrors(errors);
+        for (let i = 0; i < valid.length; i += batchSize) {
+          const batch = valid.slice(i, i + batchSize);
+          await Promise.all(
+            batch.map((item) =>
+              fetch('/api/contacts', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(item),
+              })
+            )
+          );
+        }
+        fetchContacts(globalFilter);
+      },
+    });
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-2">
+        <Input
+          placeholder="Search..."
+          value={globalFilter}
+          onChange={(e) => setGlobalFilter(e.target.value)}
+          className="max-w-sm"
+        />
+        <div className="flex gap-2">
+          <Button variant="outline" onClick={() => fileInputRef.current?.click()}>
+            Import CSV
+          </Button>
+          <Button onClick={startCreate}>Add Contact</Button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline">Columns</Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              {table.getAllLeafColumns().map((column) => (
+                <DropdownMenuCheckboxItem
+                  key={column.id}
+                  className="capitalize"
+                  checked={column.getIsVisible()}
+                  onCheckedChange={(value) => column.toggleVisibility(!!value)}
+                >
+                  {column.id}
+                </DropdownMenuCheckboxItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+        <input
+          type="file"
+          accept=".csv"
+          ref={fileInputRef}
+          onChange={handleImport}
+          className="hidden"
+        />
+      </div>
+      <Table>
+        <TableHeader>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <TableRow key={headerGroup.id}>
+              {headerGroup.headers.map((header) => (
+                <TableHead key={header.id} colSpan={header.colSpan}>
+                  {header.isPlaceholder ? null : (
+                    <div
+                      className={header.column.getCanSort() ? 'cursor-pointer select-none' : ''}
+                      onClick={header.column.getToggleSortingHandler()}
+                    >
+                      {flexRender(header.column.columnDef.header, header.getContext())}
+                      {{ asc: ' \u25B2', desc: ' \u25BC' }[
+                        header.column.getIsSorted() as string
+                      ] ?? null}
+                    </div>
+                  )}
+                </TableHead>
+              ))}
+            </TableRow>
+          ))}
+        </TableHeader>
+        <TableBody>
+          {table.getRowModel().rows.map((row) => (
+            <TableRow key={row.id}>
+              {row.getVisibleCells().map((cell) => (
+                <TableCell key={cell.id}>
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+      <div className="flex items-center justify-end gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => table.previousPage()}
+          disabled={!table.getCanPreviousPage()}
+        >
+          Previous
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => table.nextPage()}
+          disabled={!table.getCanNextPage()}
+        >
+          Next
+        </Button>
+      </div>
+      {importErrors.length > 0 && (
+        <div className="text-sm text-red-500 space-y-1">
+          {importErrors.map((err, i) => (
+            <div key={i}>{err}</div>
+          ))}
+        </div>
+      )}
+      <ContactForm
+        open={formOpen}
+        onOpenChange={setFormOpen}
+        initialData={editing}
+        onSaved={() => fetchContacts(globalFilter)}
+      />
+    </div>
+  );
+}
+

--- a/src/app/app/contacts/page.tsx
+++ b/src/app/app/contacts/page.tsx
@@ -1,3 +1,9 @@
+import ContactsTable from './contacts-table';
+
 export default function ContactsPage() {
-  return <div className="p-4">Contacts Page</div>;
+  return (
+    <div className="p-4">
+      <ContactsTable />
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- implement contact table with sorting, column toggles and CSV import
- add drawer forms for creating and editing contacts and companies
- build company list, detail and basic CRUD actions

## Testing
- `npm test`
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm install --no-audit --no-fund` *(fails: 403 Forbidden for @auth/prisma-adapter)*

------
https://chatgpt.com/codex/tasks/task_e_68c45936db7483309b4c0b39145d29da