### PR TITLE
feat: add deals board and timeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-hook-form": "^7.48.0",
+    "@hello-pangea/dnd": "^16.2.0",
     "recharts": "^2.7.2",
     "zod": "^3.22.4",
     "papaparse": "^5.4.1",

--- a/src/app/api/activities/route.ts
+++ b/src/app/api/activities/route.ts
@@ -14,10 +14,12 @@ export async function GET(req: Request) {
     );
     const { searchParams } = new URL(req.url);
     const type = searchParams.get("type") as ActivityType | null;
+    const dealId = searchParams.get("dealId") ?? undefined;
     const activities = await prisma.activity.findMany({
       where: {
         organizationId: membership.organizationId,
         ...(type ? { type } : {}),
+        ...(dealId ? { dealId } : {}),
       },
     });
     return NextResponse.json(activities);

--- a/src/app/api/deals/[id]/route.ts
+++ b/src/app/api/deals/[id]/route.ts
@@ -9,6 +9,24 @@ interface Params {
   params: { id: string };
 }
 
+export async function GET(_req: Request, { params }: Params) {
+  try {
+    const { membership } = await requireRole(
+      MembershipRole.REP,
+      MembershipRole.ADMIN,
+      MembershipRole.OWNER
+    );
+    const deal = await prisma.deal.findFirst({
+      where: { id: params.id, organizationId: membership.organizationId },
+      include: { company: true, contact: true, owner: true, stage: true },
+    });
+    if (!deal) return new Response("Not Found", { status: 404 });
+    return NextResponse.json(deal);
+  } catch (e) {
+    return handleApiError(e);
+  }
+}
+
 export async function PATCH(req: Request, { params }: Params) {
   try {
     const { membership } = await requireRole(

--- a/src/app/api/deals/route.ts
+++ b/src/app/api/deals/route.ts
@@ -14,11 +14,14 @@ export async function GET(req: Request) {
     );
     const { searchParams } = new URL(req.url);
     const status = searchParams.get("status") as DealStatus | null;
+    const pipelineId = searchParams.get("pipelineId") ?? undefined;
     const deals = await prisma.deal.findMany({
       where: {
         organizationId: membership.organizationId,
         ...(status ? { status } : {}),
+        ...(pipelineId ? { pipelineId } : {}),
       },
+      include: { company: true, contact: true, owner: true },
     });
     return NextResponse.json(deals);
   } catch (e) {

--- a/src/app/api/pipelines/route.ts
+++ b/src/app/api/pipelines/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { requireRole } from '@/lib/auth';
+import { handleApiError } from '@/lib/api';
+import { MembershipRole } from '@prisma/client';
+
+export async function GET() {
+  try {
+    const { membership } = await requireRole(
+      MembershipRole.REP,
+      MembershipRole.ADMIN,
+      MembershipRole.OWNER
+    );
+    const pipeline = await prisma.pipeline.findFirst({
+      where: { organizationId: membership.organizationId },
+      include: { stages: { orderBy: { order: 'asc' } } },
+    });
+    return NextResponse.json(pipeline);
+  } catch (e) {
+    return handleApiError(e);
+  }
+}

--- a/src/app/app/deals/[id]/page.tsx
+++ b/src/app/app/deals/[id]/page.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import { ActivityType } from '@prisma/client';
+import { formatDistanceToNow } from 'date-fns';
+
+interface Activity {
+  id: string;
+  type: ActivityType;
+  title: string;
+  note?: string | null;
+  createdAt: string;
+}
+
+interface Note {
+  id: string;
+  body: string;
+  createdAt: string;
+}
+
+interface Deal {
+  id: string;
+  title: string;
+}
+
+interface TimelineItem {
+  id: string;
+  kind: 'activity' | 'note' | 'file';
+  createdAt: string;
+  activity?: Activity;
+  note?: Note;
+  fileName?: string;
+}
+
+export default function DealDetailPage() {
+  const params = useParams();
+  const id = params?.id as string;
+  const [deal, setDeal] = useState<Deal | null>(null);
+  const [timeline, setTimeline] = useState<TimelineItem[]>([]);
+
+  useEffect(() => {
+    if (!id) return;
+    const fetchData = async () => {
+      const [dealRes, actRes, noteRes] = await Promise.all([
+        fetch(`/api/deals/${id}`),
+        fetch(`/api/activities?dealId=${id}`),
+        fetch(`/api/notes?dealId=${id}`),
+      ]);
+      if (dealRes.ok) setDeal(await dealRes.json());
+      const activities: Activity[] = actRes.ok ? await actRes.json() : [];
+      const notes: Note[] = noteRes.ok ? await noteRes.json() : [];
+      const combined: TimelineItem[] = [
+        ...activities.map((a) => ({ id: a.id, kind: 'activity', createdAt: a.createdAt, activity: a })),
+        ...notes.map((n) => ({ id: n.id, kind: 'note', createdAt: n.createdAt, note: n })),
+      ];
+      setTimeline(
+        combined.sort(
+          (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+        )
+      );
+    };
+    fetchData();
+  }, [id]);
+
+  const logActivity = async (type: ActivityType) => {
+    const title = prompt('Title')?.trim();
+    if (!title) return;
+    const temp: TimelineItem = {
+      id: 'temp-' + Math.random(),
+      kind: 'activity',
+      createdAt: new Date().toISOString(),
+      activity: { id: '', type, title, createdAt: new Date().toISOString(), note: null },
+    };
+    setTimeline((t) => [temp, ...t]);
+    await fetch('/api/activities', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type, title, dealId: id }),
+    });
+  };
+
+  const addNote = async () => {
+    const body = prompt('Note')?.trim();
+    if (!body) return;
+    const temp: TimelineItem = {
+      id: 'temp-' + Math.random(),
+      kind: 'note',
+      createdAt: new Date().toISOString(),
+      note: { id: '', body, createdAt: new Date().toISOString() },
+    };
+    setTimeline((t) => [temp, ...t]);
+    await fetch('/api/notes', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ body, dealId: id }),
+    });
+  };
+
+  const uploadFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const temp: TimelineItem = {
+      id: 'temp-' + Math.random(),
+      kind: 'file',
+      createdAt: new Date().toISOString(),
+      fileName: file.name,
+    };
+    setTimeline((t) => [temp, ...t]);
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      {deal && <h1 className="text-2xl font-bold mb-4">{deal.title}</h1>}
+      <div className="flex gap-2">
+        <button className="border px-2" onClick={() => logActivity(ActivityType.CALL)}>
+          Log Call
+        </button>
+        <button className="border px-2" onClick={() => logActivity(ActivityType.EMAIL)}>
+          Log Email
+        </button>
+        <button className="border px-2" onClick={() => logActivity(ActivityType.MEETING)}>
+          Schedule Meeting
+        </button>
+        <button className="border px-2" onClick={() => logActivity(ActivityType.TASK)}>
+          Add Task
+        </button>
+        <button className="border px-2" onClick={addNote}>
+          Add Note
+        </button>
+        <input type="file" onChange={uploadFile} />
+      </div>
+      <ul className="space-y-2">
+        {timeline.map((item) => (
+          <li key={item.id} className="border rounded p-2">
+            {item.kind === 'activity' && item.activity && (
+              <div>
+                <div className="font-medium">
+                  {item.activity.type}: {item.activity.title}
+                </div>
+                <div className="text-xs text-gray-500">
+                  {formatDistanceToNow(new Date(item.createdAt), { addSuffix: true })}
+                </div>
+              </div>
+            )}
+            {item.kind === 'note' && item.note && (
+              <div>
+                <div>{item.note.body}</div>
+                <div className="text-xs text-gray-500">
+                  {formatDistanceToNow(new Date(item.createdAt), { addSuffix: true })}
+                </div>
+              </div>
+            )}
+            {item.kind === 'file' && (
+              <div>
+                <div>Uploaded file: {item.fileName}</div>
+                <div className="text-xs text-gray-500">
+                  {formatDistanceToNow(new Date(item.createdAt), { addSuffix: true })}
+                </div>
+              </div>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/app/app/deals/board/page.tsx
+++ b/src/app/app/deals/board/page.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import {
+  DragDropContext,
+  Droppable,
+  Draggable,
+  DropResult,
+} from '@hello-pangea/dnd';
+import { formatDistanceToNow } from 'date-fns';
+
+interface Stage {
+  id: string;
+  name: string;
+}
+
+interface Pipeline {
+  id: string;
+  stages: Stage[];
+}
+
+interface Deal {
+  id: string;
+  title: string;
+  valueCents: number;
+  company?: { name: string } | null;
+  contact?: { firstName: string; lastName: string } | null;
+  owner?: { name: string | null; email: string } | null;
+  stageId: string;
+  createdAt: string;
+}
+
+export default function DealsBoardPage() {
+  const [pipeline, setPipeline] = useState<Pipeline | null>(null);
+  const [deals, setDeals] = useState<Deal[]>([]);
+
+  useEffect(() => {
+    const fetchPipeline = async () => {
+      const res = await fetch('/api/pipelines');
+      if (res.ok) setPipeline(await res.json());
+    };
+    fetchPipeline();
+  }, []);
+
+  useEffect(() => {
+    if (!pipeline) return;
+    const fetchDeals = async () => {
+      const res = await fetch(`/api/deals?pipelineId=${pipeline.id}`);
+      if (res.ok) setDeals(await res.json());
+    };
+    fetchDeals();
+  }, [pipeline]);
+
+  const onDragEnd = async (result: DropResult) => {
+    if (!result.destination) return;
+    const stageId = result.destination.droppableId;
+    setDeals((prev) =>
+      prev.map((d) => (d.id === result.draggableId ? { ...d, stageId } : d))
+    );
+    await fetch(`/api/deals/${result.draggableId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ stageId }),
+    });
+  };
+
+  const stageDeals = (stageId: string) =>
+    deals.filter((d) => d.stageId === stageId);
+
+  return (
+    <div className="p-4">
+      {pipeline && (
+        <DragDropContext onDragEnd={onDragEnd}>
+          <div className="flex gap-4 overflow-x-auto">
+            {pipeline.stages.map((stage) => (
+              <Droppable droppableId={stage.id} key={stage.id}>
+                {(provided) => (
+                  <div
+                    ref={provided.innerRef}
+                    {...provided.droppableProps}
+                    className="bg-gray-100 rounded p-2 min-w-[250px]"
+                  >
+                    <h3 className="font-semibold mb-2">{stage.name}</h3>
+                    {stageDeals(stage.id).map((deal, index) => (
+                      <Draggable
+                        draggableId={deal.id}
+                        index={index}
+                        key={deal.id}
+                      >
+                        {(prov) => (
+                          <div
+                            ref={prov.innerRef}
+                            {...prov.draggableProps}
+                            {...prov.dragHandleProps}
+                            className="bg-white rounded shadow p-2 mb-2"
+                          >
+                            <div className="font-medium">{deal.title}</div>
+                            <div className="text-sm text-gray-500">
+                              ${(deal.valueCents / 100).toFixed(2)}
+                            </div>
+                            <div className="text-sm">
+                              {deal.company?.name ||
+                                `${deal.contact?.firstName ?? ''} ${
+                                  deal.contact?.lastName ?? ''
+                                }`}
+                            </div>
+                            <div className="text-xs text-gray-400">
+                              {(deal.owner?.name || deal.owner?.email) +
+                                ' • ' +
+                                formatDistanceToNow(new Date(deal.createdAt), {
+                                  addSuffix: true,
+                                })}
+                            </div>
+                          </div>
+                        )}
+                      </Draggable>
+                    ))}
+                    {provided.placeholder}
+                  </div>
+                )}
+              </Droppable>
+            ))}
+          </div>
+        </DragDropContext>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement pipeline board with drag-and-drop stages
- show deal timeline with activities, notes, and quick actions
- expose pipeline and deal APIs for board and detail views

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test`
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c45b60cb308330b0a78c5b377a418c