### PR TITLE
Add tasks view and call logging helper

### DIFF
--- a/src/app/app/deals/[id]/call-log-dialog.tsx
+++ b/src/app/app/deals/[id]/call-log-dialog.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { useState } from 'react';
+import { z } from 'zod';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { ActivityType } from '@prisma/client';
+
+const schema = z.object({
+  outcome: z.string().trim().min(1),
+  duration: z.string().trim().optional(),
+  followUp: z.string().optional(),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+interface Props {
+  dealId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onLogged?: () => void;
+}
+
+export default function CallLogDialog({
+  dealId,
+  open,
+  onOpenChange,
+  onLogged,
+}: Props) {
+  const form = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { outcome: '', duration: '', followUp: '' },
+  });
+  const [saving, setSaving] = useState(false);
+
+  const onSubmit = async (values: FormValues) => {
+    setSaving(true);
+    await fetch('/api/activities', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        dealId,
+        type: ActivityType.CALL,
+        title: values.outcome,
+        note: values.duration ? `Duration: ${values.duration}` : undefined,
+      }),
+    });
+    if (values.followUp) {
+      await fetch('/api/activities', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          dealId,
+          type: ActivityType.TASK,
+          title: 'Follow up call',
+          dueAt: new Date(values.followUp).toISOString(),
+        }),
+      });
+    }
+    setSaving(false);
+    onOpenChange(false);
+    form.reset();
+    onLogged?.();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Log Call</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="outcome">Outcome</Label>
+            <Input id="outcome" {...form.register('outcome')} />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="duration">Duration</Label>
+            <Input
+              id="duration"
+              placeholder="5m"
+              {...form.register('duration')}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="followUp">Next Follow-up</Label>
+            <Input id="followUp" type="date" {...form.register('followUp')} />
+          </div>
+          <DialogFooter>
+            <Button type="submit" disabled={saving}>
+              {saving ? 'Saving...' : 'Save'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+

--- a/src/app/app/tasks/page.tsx
+++ b/src/app/app/tasks/page.tsx
@@ -1,3 +1,9 @@
+import TasksTable from './tasks-table';
+
 export default function TasksPage() {
-  return <div className="p-4">Tasks Page</div>;
+  return (
+    <div className="p-4">
+      <TasksTable />
+    </div>
+  );
 }

--- a/src/app/app/tasks/tasks-table.tsx
+++ b/src/app/app/tasks/tasks-table.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { format } from 'date-fns';
+import { useRouter } from 'next/navigation';
+import { cn } from '@/lib/utils';
+
+interface Task {
+  id: string;
+  title: string;
+  dueAt?: string | null;
+  completedAt?: string | null;
+}
+
+type Filter = 'today' | 'week' | 'overdue' | 'mine' | 'team';
+
+export default function TasksTable() {
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [filter, setFilter] = useState<Filter>('today');
+  const router = useRouter();
+
+  const fetchTasks = async () => {
+    const params = new URLSearchParams({ type: 'TASK' });
+    switch (filter) {
+      case 'today':
+        params.set('owner', 'mine');
+        params.set('due', 'today');
+        break;
+      case 'week':
+        params.set('owner', 'mine');
+        params.set('due', 'week');
+        break;
+      case 'overdue':
+        params.set('owner', 'mine');
+        params.set('due', 'overdue');
+        break;
+      case 'mine':
+        params.set('owner', 'mine');
+        break;
+      case 'team':
+        params.set('owner', 'team');
+        break;
+    }
+    const res = await fetch('/api/activities?' + params.toString());
+    if (res.ok) {
+      setTasks(await res.json());
+    }
+  };
+
+  useEffect(() => {
+    fetchTasks();
+  }, [filter]);
+
+  const toggleComplete = async (task: Task) => {
+    await fetch(`/api/activities/${task.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        completedAt: task.completedAt ? null : new Date().toISOString(),
+      }),
+    });
+    await fetchTasks();
+    router.refresh();
+  };
+
+  const filters: { key: Filter; label: string }[] = [
+    { key: 'today', label: 'Today' },
+    { key: 'week', label: 'This Week' },
+    { key: 'overdue', label: 'Overdue' },
+    { key: 'mine', label: 'Mine' },
+    { key: 'team', label: 'Team' },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap gap-2">
+        {filters.map((f) => (
+          <Button
+            key={f.key}
+            variant={filter === f.key ? 'default' : 'outline'}
+            onClick={() => setFilter(f.key)}
+          >
+            {f.label}
+          </Button>
+        ))}
+      </div>
+      <ul className="space-y-2">
+        {tasks.map((t) => {
+          const isOverdue =
+            t.dueAt && new Date(t.dueAt) < new Date() && !t.completedAt;
+          return (
+            <li
+              key={t.id}
+              className="flex items-center justify-between border rounded p-2"
+            >
+              <div>
+                <div
+                  className={cn(
+                    t.completedAt ? 'line-through text-muted-foreground' : ''
+                  )}
+                >
+                  {t.title}
+                </div>
+                {t.dueAt && (
+                  <div
+                    className={cn(
+                      'text-xs',
+                      isOverdue && !t.completedAt
+                        ? 'text-red-500'
+                        : 'text-muted-foreground'
+                    )}
+                  >
+                    {format(new Date(t.dueAt), 'MMM d, yyyy')}
+                  </div>
+                )}
+              </div>
+              <input
+                type="checkbox"
+                checked={!!t.completedAt}
+                onChange={() => toggleComplete(t)}
+              />
+            </li>
+          );
+        })}
+        {tasks.length === 0 && (
+          <li className="text-sm text-muted-foreground">No tasks.</li>
+        )}
+      </ul>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- extend activities API with owner and due filters
- add tasks page with quick filters and completion toggle
- provide call logging dialog that can schedule follow-up tasks

## Testing
- `npm test`
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm install` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68c46632de088330a594fd87c1f82047