### PR TITLE
feat: add full text search

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireRole } from "@/lib/auth";
+import { handleApiError } from "@/lib/api";
+import { MembershipRole } from "@prisma/client";
+
+export async function GET(req: Request) {
+  try {
+    const { membership } = await requireRole(
+      MembershipRole.REP,
+      MembershipRole.ADMIN,
+      MembershipRole.OWNER
+    );
+    const { searchParams } = new URL(req.url);
+    const q = searchParams.get("q");
+    if (!q) {
+      return NextResponse.json([]);
+    }
+
+    const orgId = membership.organizationId;
+    const results = await prisma.$queryRaw<
+      { type: string; id: string; label: string }[]
+    >`
+      SELECT 'company' AS type, id, name AS label
+      FROM "Company"
+      WHERE "organizationId" = ${orgId}
+        AND to_tsvector('simple', coalesce(name,'') || ' ' || coalesce(domain,'')) @@ plainto_tsquery('simple', ${q})
+      UNION ALL
+      SELECT 'contact' AS type, id, (coalesce("firstName",'') || ' ' || coalesce("lastName",'')) AS label
+      FROM "Contact"
+      WHERE "organizationId" = ${orgId}
+        AND to_tsvector('simple', coalesce("firstName",'') || ' ' || coalesce("lastName",'') || ' ' || coalesce(email,'')) @@ plainto_tsquery('simple', ${q})
+      UNION ALL
+      SELECT 'deal' AS type, id, title AS label
+      FROM "Deal"
+      WHERE "organizationId" = ${orgId}
+        AND to_tsvector('simple', coalesce(title,'')) @@ plainto_tsquery('simple', ${q})
+      LIMIT 20
+    `;
+
+    return NextResponse.json(results);
+  } catch (e) {
+    return handleApiError(e);
+  }
+}

--- a/src/app/app/_components/global-search.tsx
+++ b/src/app/app/_components/global-search.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { Input } from "@/components/ui/input";
+
+interface Result {
+  type: string;
+  id: string;
+  label: string;
+}
+
+export default function GlobalSearch() {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<Result[]>([]);
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!query) {
+      setResults([]);
+      return;
+    }
+    const controller = new AbortController();
+    const load = async () => {
+      const res = await fetch(`/api/search?q=${encodeURIComponent(query)}`, {
+        signal: controller.signal,
+      });
+      if (res.ok) {
+        setResults(await res.json());
+      }
+    };
+    load();
+    return () => controller.abort();
+  }, [query]);
+
+  const handleSelect = (r: Result) => {
+    let path = "";
+    if (r.type === "company") path = `/app/companies/${r.id}`;
+    else if (r.type === "contact") path = `/app/contacts/${r.id}`;
+    else if (r.type === "deal") path = `/app/deals/${r.id}`;
+    if (path) router.push(path);
+    setQuery("");
+    setResults([]);
+  };
+
+  return (
+    <div className="relative w-64">
+      <Input
+        placeholder="Search..."
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+      />
+      {results.length > 0 && (
+        <div className="absolute z-10 mt-1 w-full rounded-md border bg-background text-sm shadow">
+          {results.map((r) => (
+            <div
+              key={`${r.type}-${r.id}`}
+              className="cursor-pointer px-2 py-1 hover:bg-accent"
+              onClick={() => handleSelect(r)}
+            >
+              {r.label}
+              <span className="ml-1 text-muted-foreground">({r.type})</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/app/_components/topbar.tsx
+++ b/src/app/app/_components/topbar.tsx
@@ -14,21 +14,25 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
 } from "@/components/ui/dropdown-menu";
+import GlobalSearch from "./global-search";
 
 export default function Topbar() {
   return (
     <div className="flex h-14 items-center justify-between border-b px-4">
-      <Sheet>
-        <SheetTrigger asChild>
-          <Button variant="ghost" size="icon" className="md:hidden">
-            <Menu className="h-5 w-5" />
-            <span className="sr-only">Toggle menu</span>
-          </Button>
-        </SheetTrigger>
-        <SheetContent side="left" className="p-0 w-64">
-          <Sidebar />
-        </SheetContent>
-      </Sheet>
+      <div className="flex items-center gap-2">
+        <Sheet>
+          <SheetTrigger asChild>
+            <Button variant="ghost" size="icon" className="md:hidden">
+              <Menu className="h-5 w-5" />
+              <span className="sr-only">Toggle menu</span>
+            </Button>
+          </SheetTrigger>
+          <SheetContent side="left" className="p-0 w-64">
+            <Sidebar />
+          </SheetContent>
+        </Sheet>
+        <GlobalSearch />
+      </div>
       <div className="flex items-center gap-2">
         <OrgSwitcher />
         <UserNav />


### PR DESCRIPTION
## Summary
- add global search API backed by Postgres full-text search across companies, contacts, and deals
- introduce topbar search component to navigate directly to entity details

## Testing
- `npm test`
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c467f2b8e483309675a5134c0a14f9