### PR TITLE
feat: send emails and log as activities

### DIFF
--- a/src/app/api/emails/route.ts
+++ b/src/app/api/emails/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireRole } from "@/lib/auth";
+import { handleApiError } from "@/lib/api";
+import { MembershipRole, ActivityType } from "@prisma/client";
+import { sendEmail } from "@/lib/email";
+import { z } from "zod";
+
+const schema = z.object({
+  to: z.string().email(),
+  subject: z.string().trim().min(1),
+  body: z.string().trim().min(1),
+  dealId: z.string().cuid().optional(),
+  contactId: z.string().cuid().optional(),
+});
+
+export async function POST(req: Request) {
+  try {
+    const { membership, user } = await requireRole(
+      MembershipRole.REP,
+      MembershipRole.ADMIN,
+      MembershipRole.OWNER
+    );
+    const data = schema.parse(await req.json());
+    await sendEmail({
+      to: data.to,
+      subject: data.subject,
+      html: `<p>${data.body.replace(/\n/g, "<br/>")}</p>`,
+      text: data.body,
+    });
+    const activity = await prisma.activity.create({
+      data: {
+        organizationId: membership.organizationId,
+        ownerId: user.id,
+        dealId: data.dealId,
+        contactId: data.contactId,
+        type: ActivityType.EMAIL,
+        title: data.subject,
+        note: data.body.slice(0, 200),
+      },
+    });
+    return NextResponse.json(activity, { status: 201 });
+  } catch (e) {
+    return handleApiError(e);
+  }
+}

--- a/src/app/app/deals/[id]/page.tsx
+++ b/src/app/app/deals/[id]/page.tsx
@@ -93,6 +93,34 @@ export default function DealDetailPage() {
     });
   };
 
+  const sendEmail = async () => {
+    const to = prompt('To')?.trim();
+    if (!to) return;
+    const subject = prompt('Subject')?.trim();
+    if (!subject) return;
+    const body = prompt('Body')?.trim();
+    if (!body) return;
+    const temp: TimelineItem = {
+      id: 'temp-' + Math.random(),
+      kind: 'activity',
+      createdAt: new Date().toISOString(),
+      activity: {
+        id: '',
+        type: ActivityType.EMAIL,
+        title: subject,
+        note: body,
+        createdAt: new Date().toISOString(),
+      },
+    };
+    setTimeline((t) => [temp, ...t]);
+    await fetch('/api/emails', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ to, subject, body, dealId: id }),
+    });
+    await fetchData();
+  };
+
   const addNote = async () => {
     const body = prompt('Note')?.trim();
     if (!body) return;
@@ -133,8 +161,8 @@ export default function DealDetailPage() {
           onOpenChange={setCallOpen}
           onLogged={fetchData}
         />
-        <button className="border px-2" onClick={() => logActivity(ActivityType.EMAIL)}>
-          Log Email
+        <button className="border px-2" onClick={sendEmail}>
+          Send Email
         </button>
         <button className="border px-2" onClick={() => logActivity(ActivityType.MEETING)}>
           Schedule Meeting
@@ -155,6 +183,9 @@ export default function DealDetailPage() {
                 <div className="font-medium">
                   {item.activity.type}: {item.activity.title}
                 </div>
+                {item.activity.note && (
+                  <div className="text-sm">{item.activity.note}</div>
+                )}
                 <div className="text-xs text-gray-500">
                   {formatDistanceToNow(new Date(item.createdAt), { addSuffix: true })}
                 </div>

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -20,3 +20,66 @@ export async function sendVerificationEmail(email: string, token: string) {
     console.log(`Verification link for ${email}: ${verifyUrl}`);
   }
 }
+
+interface SendEmailOptions {
+  to: string;
+  subject: string;
+  html: string;
+  text?: string;
+}
+
+export async function sendEmail({
+  to,
+  subject,
+  html,
+  text,
+}: SendEmailOptions) {
+  if (
+    process.env.ZOHO_SMTP_HOST &&
+    process.env.ZOHO_SMTP_USER &&
+    process.env.ZOHO_SMTP_PASS
+  ) {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      // @ts-ignore
+      const nodemailer = require("nodemailer");
+      const transporter = nodemailer.createTransport({
+        host: process.env.ZOHO_SMTP_HOST,
+        port: Number(process.env.ZOHO_SMTP_PORT) || 465,
+        secure: true,
+        auth: {
+          user: process.env.ZOHO_SMTP_USER,
+          pass: process.env.ZOHO_SMTP_PASS,
+        },
+      });
+      await transporter.sendMail({
+        from: process.env.ZOHO_SMTP_FROM || process.env.ZOHO_SMTP_USER,
+        to,
+        subject,
+        html,
+        text,
+      });
+      return;
+    } catch (err) {
+      console.error("SMTP send failed", err);
+    }
+  }
+
+  if (process.env.RESEND_API_KEY) {
+    await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${process.env.RESEND_API_KEY}`,
+      },
+      body: JSON.stringify({
+        from: process.env.RESEND_FROM || "noreply@example.com",
+        to,
+        subject,
+        html,
+      }),
+    });
+  } else {
+    console.log(`Email to ${to}: ${subject}\n${text || ""}`);
+  }
+}


### PR DESCRIPTION
## Summary
- support SMTP/Resend email sending utilities
- add POST /api/emails endpoint that sends email and logs an activity
- enable email sending from deal page with timeline preview

## Testing
- `npm test`
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c47024c8f8833095919bdf53cdbc5d