### PR TITLE
feat: add audit logging for entity changes

### DIFF
--- a/src/app/api/activities/[id]/route.ts
+++ b/src/app/api/activities/[id]/route.ts
@@ -4,6 +4,7 @@ import { requireRole } from "@/lib/auth";
 import { activitySchema } from "@/lib/validators";
 import { handleApiError } from "@/lib/api";
 import { MembershipRole } from "@prisma/client";
+import { createAuditLog } from "@/lib/audit";
 
 interface Params {
   params: { id: string };
@@ -11,7 +12,7 @@ interface Params {
 
 export async function PATCH(req: Request, { params }: Params) {
   try {
-    const { membership } = await requireRole(
+    const { membership, user } = await requireRole(
       MembershipRole.REP,
       MembershipRole.ADMIN,
       MembershipRole.OWNER
@@ -25,6 +26,15 @@ export async function PATCH(req: Request, { params }: Params) {
       where: { id: params.id },
       data,
     });
+    await createAuditLog({
+      organizationId: membership.organizationId,
+      userId: user.id,
+      action: "UPDATE",
+      entityType: "Activity",
+      entityId: activity.id,
+      before: existing,
+      after: activity,
+    });
     return NextResponse.json(activity);
   } catch (e) {
     return handleApiError(e);
@@ -33,7 +43,7 @@ export async function PATCH(req: Request, { params }: Params) {
 
 export async function DELETE(_req: Request, { params }: Params) {
   try {
-    const { membership } = await requireRole(
+    const { membership, user } = await requireRole(
       MembershipRole.REP,
       MembershipRole.ADMIN,
       MembershipRole.OWNER
@@ -43,6 +53,14 @@ export async function DELETE(_req: Request, { params }: Params) {
     });
     if (!existing) return new Response("Not Found", { status: 404 });
     await prisma.activity.delete({ where: { id: params.id } });
+    await createAuditLog({
+      organizationId: membership.organizationId,
+      userId: user.id,
+      action: "DELETE",
+      entityType: "Activity",
+      entityId: existing.id,
+      before: existing,
+    });
     return new Response(null, { status: 204 });
   } catch (e) {
     return handleApiError(e);

--- a/src/app/api/activities/route.ts
+++ b/src/app/api/activities/route.ts
@@ -5,6 +5,7 @@ import { activitySchema } from "@/lib/validators";
 import { handleApiError } from "@/lib/api";
 import { MembershipRole, ActivityType } from "@prisma/client";
 import { rateLimitWrite } from "@/lib/rate-limit";
+import { createAuditLog } from "@/lib/audit";
 import {
   startOfDay,
   endOfDay,
@@ -77,6 +78,14 @@ export async function POST(req: Request) {
         organizationId: membership.organizationId,
         ownerId: user.id,
       },
+    });
+    await createAuditLog({
+      organizationId: membership.organizationId,
+      userId: user.id,
+      action: "CREATE",
+      entityType: "Activity",
+      entityId: activity.id,
+      after: activity,
     });
     return NextResponse.json(activity, { status: 201 });
   } catch (e) {

--- a/src/app/api/companies/route.ts
+++ b/src/app/api/companies/route.ts
@@ -5,6 +5,7 @@ import { companySchema } from "@/lib/validators";
 import { handleApiError } from "@/lib/api";
 import { MembershipRole } from "@prisma/client";
 import { rateLimitWrite } from "@/lib/rate-limit";
+import { createAuditLog } from "@/lib/audit";
 
 // GET list of companies & POST create new company
 export async function GET(req: Request) {
@@ -48,6 +49,14 @@ export async function POST(req: Request) {
         organizationId: membership.organizationId,
         ownerId: user.id,
       },
+    });
+    await createAuditLog({
+      organizationId: membership.organizationId,
+      userId: user.id,
+      action: "CREATE",
+      entityType: "Company",
+      entityId: company.id,
+      after: company,
     });
     return NextResponse.json(company, { status: 201 });
   } catch (e) {

--- a/src/app/api/contacts/route.ts
+++ b/src/app/api/contacts/route.ts
@@ -5,6 +5,7 @@ import { contactSchema } from "@/lib/validators";
 import { handleApiError } from "@/lib/api";
 import { MembershipRole } from "@prisma/client";
 import { rateLimitWrite } from "@/lib/rate-limit";
+import { createAuditLog } from "@/lib/audit";
 
 export async function GET(req: Request) {
   try {
@@ -55,6 +56,14 @@ export async function POST(req: Request) {
         organizationId: membership.organizationId,
         ownerId: user.id,
       },
+    });
+    await createAuditLog({
+      organizationId: membership.organizationId,
+      userId: user.id,
+      action: "CREATE",
+      entityType: "Contact",
+      entityId: contact.id,
+      after: contact,
     });
     return NextResponse.json(contact, { status: 201 });
   } catch (e) {

--- a/src/app/api/deals/route.ts
+++ b/src/app/api/deals/route.ts
@@ -5,6 +5,7 @@ import { dealSchema } from "@/lib/validators";
 import { handleApiError } from "@/lib/api";
 import { MembershipRole, DealStatus } from "@prisma/client";
 import { rateLimitWrite } from "@/lib/rate-limit";
+import { createAuditLog } from "@/lib/audit";
 
 export async function GET(req: Request) {
   try {
@@ -51,6 +52,14 @@ export async function POST(req: Request) {
         organizationId: membership.organizationId,
         ownerId: user.id,
       },
+    });
+    await createAuditLog({
+      organizationId: membership.organizationId,
+      userId: user.id,
+      action: "CREATE",
+      entityType: "Deal",
+      entityId: deal.id,
+      after: deal,
     });
     return NextResponse.json(deal, { status: 201 });
   } catch (e) {

--- a/src/app/api/notes/[id]/route.ts
+++ b/src/app/api/notes/[id]/route.ts
@@ -4,6 +4,7 @@ import { requireRole } from "@/lib/auth";
 import { noteSchema } from "@/lib/validators";
 import { handleApiError } from "@/lib/api";
 import { MembershipRole } from "@prisma/client";
+import { createAuditLog } from "@/lib/audit";
 
 interface Params {
   params: { id: string };
@@ -11,7 +12,7 @@ interface Params {
 
 export async function PATCH(req: Request, { params }: Params) {
   try {
-    const { membership } = await requireRole(
+    const { membership, user } = await requireRole(
       MembershipRole.REP,
       MembershipRole.ADMIN,
       MembershipRole.OWNER
@@ -25,6 +26,15 @@ export async function PATCH(req: Request, { params }: Params) {
       where: { id: params.id },
       data,
     });
+    await createAuditLog({
+      organizationId: membership.organizationId,
+      userId: user.id,
+      action: "UPDATE",
+      entityType: "Note",
+      entityId: note.id,
+      before: existing,
+      after: note,
+    });
     return NextResponse.json(note);
   } catch (e) {
     return handleApiError(e);
@@ -33,7 +43,7 @@ export async function PATCH(req: Request, { params }: Params) {
 
 export async function DELETE(_req: Request, { params }: Params) {
   try {
-    const { membership } = await requireRole(
+    const { membership, user } = await requireRole(
       MembershipRole.REP,
       MembershipRole.ADMIN,
       MembershipRole.OWNER
@@ -43,6 +53,14 @@ export async function DELETE(_req: Request, { params }: Params) {
     });
     if (!existing) return new Response("Not Found", { status: 404 });
     await prisma.note.delete({ where: { id: params.id } });
+    await createAuditLog({
+      organizationId: membership.organizationId,
+      userId: user.id,
+      action: "DELETE",
+      entityType: "Note",
+      entityId: existing.id,
+      before: existing,
+    });
     return new Response(null, { status: 204 });
   } catch (e) {
     return handleApiError(e);

--- a/src/app/api/notes/route.ts
+++ b/src/app/api/notes/route.ts
@@ -5,6 +5,7 @@ import { noteSchema } from "@/lib/validators";
 import { handleApiError } from "@/lib/api";
 import { MembershipRole } from "@prisma/client";
 import { rateLimitWrite } from "@/lib/rate-limit";
+import { createAuditLog } from "@/lib/audit";
 
 export async function GET(req: Request) {
   try {
@@ -50,6 +51,14 @@ export async function POST(req: Request) {
         organizationId: membership.organizationId,
         authorId: user.id,
       },
+    });
+    await createAuditLog({
+      organizationId: membership.organizationId,
+      userId: user.id,
+      action: "CREATE",
+      entityType: "Note",
+      entityId: note.id,
+      after: note,
     });
     return NextResponse.json(note, { status: 201 });
   } catch (e) {

--- a/src/app/app/settings/audit/page.tsx
+++ b/src/app/app/settings/audit/page.tsx
@@ -1,0 +1,95 @@
+import Link from "next/link";
+import { prisma } from "@/lib/prisma";
+import { requireRole } from "@/lib/auth";
+import { MembershipRole } from "@prisma/client";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+const PAGE_SIZE = 20;
+
+export default async function AuditLogPage({
+  searchParams,
+}: {
+  searchParams: { page?: string };
+}) {
+  const page = Math.max(1, Number(searchParams?.page) || 1);
+  const { membership } = await requireRole(
+    MembershipRole.ADMIN,
+    MembershipRole.OWNER
+  );
+  const [logs, total] = await Promise.all([
+    prisma.auditLog.findMany({
+      where: { organizationId: membership.organizationId },
+      include: { user: true },
+      orderBy: { createdAt: "desc" },
+      skip: (page - 1) * PAGE_SIZE,
+      take: PAGE_SIZE,
+    }),
+    prisma.auditLog.count({
+      where: { organizationId: membership.organizationId },
+    }),
+  ]);
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Audit Log</h1>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Date</TableHead>
+            <TableHead>User</TableHead>
+            <TableHead>Action</TableHead>
+            <TableHead>Entity</TableHead>
+            <TableHead>Changes</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {logs.map((log) => (
+            <TableRow key={log.id}>
+              <TableCell>{log.createdAt.toLocaleString()}</TableCell>
+              <TableCell>{log.user?.name || ""}</TableCell>
+              <TableCell>{log.action}</TableCell>
+              <TableCell>
+                {log.entityType} {log.entityId}
+              </TableCell>
+              <TableCell>
+                {Object.entries(log.changes as any).map(([key, change]) => (
+                  <div key={key} className="text-xs">
+                    <strong>{key}</strong>: {JSON.stringify((change as any).before)} → {JSON.stringify((change as any).after)}
+                  </div>
+                ))}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+      <div className="flex justify-between items-center">
+        <Link
+          className={`text-sm ${page <= 1 ? "pointer-events-none opacity-50" : ""}`}
+          href={`/app/settings/audit?page=${page - 1}`}
+        >
+          Previous
+        </Link>
+        <div className="text-sm">
+          Page {page} of {totalPages}
+        </div>
+        <Link
+          className={`text-sm ${
+            page >= totalPages ? "pointer-events-none opacity-50" : ""
+          }`}
+          href={`/app/settings/audit?page=${page + 1}`}
+        >
+          Next
+        </Link>
+      </div>
+    </div>
+  );
+}
+

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -1,0 +1,47 @@
+import { prisma } from "@/lib/prisma";
+
+interface AuditOptions {
+  organizationId: string;
+  userId?: string;
+  action: string;
+  entityType: string;
+  entityId: string;
+  before?: Record<string, any> | null;
+  after?: Record<string, any> | null;
+}
+
+function diffObjects(
+  before: Record<string, any> | null | undefined,
+  after: Record<string, any> | null | undefined
+) {
+  const changes: Record<string, { before: any; after: any }> = {};
+  const keys = new Set([
+    ...Object.keys(before || {}),
+    ...Object.keys(after || {}),
+  ]);
+  for (const key of keys) {
+    const b = before ? before[key] : undefined;
+    const a = after ? after[key] : undefined;
+    if (JSON.stringify(b) !== JSON.stringify(a)) {
+      changes[key] = { before: b, after: a };
+    }
+  }
+  return changes;
+}
+
+export async function createAuditLog(options: AuditOptions) {
+  const { organizationId, userId, action, entityType, entityId, before, after } =
+    options;
+  const changes = diffObjects(before, after);
+  await prisma.auditLog.create({
+    data: {
+      organizationId,
+      userId,
+      action,
+      entityType,
+      entityId,
+      changes,
+    },
+  });
+}
+


### PR DESCRIPTION
## Summary
- log create/update/delete operations using new audit log utility
- expose paginated audit log page for admins and owners

## Testing
- `npm test`
- `npx tsc --noEmit` *(fails: src/components/ui/use-toast.ts... error TS1005: '>' expected.)*

------
https://chatgpt.com/codex/tasks/task_e_68c48129093083308de127cdf7f75843