### PR TITLE
feat: manage organization and members

### DIFF
--- a/src/app/api/memberships/[id]/route.ts
+++ b/src/app/api/memberships/[id]/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireRole } from "@/lib/auth";
+import { handleApiError } from "@/lib/api";
+import { membershipSchema } from "@/lib/validators";
+import { MembershipRole } from "@prisma/client";
+
+export async function PATCH(req: Request, { params }: { params: { id: string } }) {
+  try {
+    const { membership } = await requireRole(MembershipRole.OWNER);
+    const existing = await prisma.membership.findUnique({ where: { id: params.id } });
+    if (!existing || existing.organizationId !== membership.organizationId) {
+      return new NextResponse("Not found", { status: 404 });
+    }
+    const data = membershipSchema.parse(await req.json());
+    const updated = await prisma.membership.update({
+      where: { id: params.id },
+      data,
+    });
+    return NextResponse.json(updated);
+  } catch (e) {
+    return handleApiError(e);
+  }
+}
+
+export async function DELETE(req: Request, { params }: { params: { id: string } }) {
+  try {
+    const { membership } = await requireRole(MembershipRole.OWNER);
+    const existing = await prisma.membership.findUnique({ where: { id: params.id } });
+    if (!existing || existing.organizationId !== membership.organizationId) {
+      return new NextResponse("Not found", { status: 404 });
+    }
+    await prisma.membership.delete({ where: { id: params.id } });
+    return NextResponse.json({ success: true });
+  } catch (e) {
+    return handleApiError(e);
+  }
+}

--- a/src/app/api/memberships/route.ts
+++ b/src/app/api/memberships/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireRole } from "@/lib/auth";
+import { handleApiError } from "@/lib/api";
+import { inviteSchema } from "@/lib/validators";
+import { MembershipRole } from "@prisma/client";
+import { sendInvitationEmail } from "@/lib/email";
+
+export async function GET() {
+  try {
+    const { membership } = await requireRole(MembershipRole.OWNER);
+    const members = await prisma.membership.findMany({
+      where: { organizationId: membership.organizationId },
+      include: { user: true },
+    });
+    return NextResponse.json(members);
+  } catch (e) {
+    return handleApiError(e);
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const { membership } = await requireRole(MembershipRole.OWNER);
+    const { email, role } = inviteSchema.parse(await req.json());
+    let user = await prisma.user.findUnique({ where: { email } });
+    if (!user) {
+      user = await prisma.user.create({ data: { email } });
+    }
+    const existing = await prisma.membership.findFirst({
+      where: { userId: user.id, organizationId: membership.organizationId },
+    });
+    if (existing) {
+      return NextResponse.json({ error: "Already a member" }, { status: 400 });
+    }
+    const member = await prisma.membership.create({
+      data: {
+        userId: user.id,
+        organizationId: membership.organizationId,
+        role,
+      },
+    });
+    await sendInvitationEmail(email);
+    return NextResponse.json(member, { status: 201 });
+  } catch (e) {
+    return handleApiError(e);
+  }
+}

--- a/src/app/api/organization/route.ts
+++ b/src/app/api/organization/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireRole } from "@/lib/auth";
+import { handleApiError } from "@/lib/api";
+import { organizationSchema } from "@/lib/validators";
+import { MembershipRole } from "@prisma/client";
+
+export async function GET() {
+  try {
+    const { membership } = await requireRole(MembershipRole.OWNER);
+    const org = await prisma.organization.findUnique({
+      where: { id: membership.organizationId },
+    });
+    return NextResponse.json(org);
+  } catch (e) {
+    return handleApiError(e);
+  }
+}
+
+export async function PUT(req: Request) {
+  try {
+    const { membership } = await requireRole(MembershipRole.OWNER);
+    const data = organizationSchema.parse(await req.json());
+    const org = await prisma.organization.update({
+      where: { id: membership.organizationId },
+      data,
+    });
+    return NextResponse.json(org);
+  } catch (e) {
+    return handleApiError(e);
+  }
+}
+
+export async function DELETE() {
+  try {
+    const { membership } = await requireRole(MembershipRole.OWNER);
+    await prisma.organization.delete({ where: { id: membership.organizationId } });
+    return NextResponse.json({ success: true });
+  } catch (e) {
+    return handleApiError(e);
+  }
+}

--- a/src/app/app/settings/organization/page.tsx
+++ b/src/app/app/settings/organization/page.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { MembershipRole } from '@prisma/client';
+
+interface Member {
+  id: string;
+  role: MembershipRole;
+  user: { email: string };
+}
+
+export default function OrganizationSettingsPage() {
+  const [name, setName] = useState('');
+  const [slug, setSlug] = useState('');
+  const [members, setMembers] = useState<Member[]>([]);
+  const [inviteEmail, setInviteEmail] = useState('');
+  const [inviteRole, setInviteRole] = useState<MembershipRole>(MembershipRole.REP);
+
+  const fetchData = async () => {
+    const orgRes = await fetch('/api/organization');
+    if (orgRes.ok) {
+      const org = await orgRes.json();
+      setName(org.name || '');
+      setSlug(org.slug || '');
+    }
+    const memRes = await fetch('/api/memberships');
+    if (memRes.ok) {
+      const ms = await memRes.json();
+      setMembers(ms);
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  const saveOrg = async () => {
+    await fetch('/api/organization', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, slug }),
+    });
+    fetchData();
+  };
+
+  const deleteOrg = async () => {
+    await fetch('/api/organization', { method: 'DELETE' });
+  };
+
+  const invite = async () => {
+    await fetch('/api/memberships', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: inviteEmail, role: inviteRole }),
+    });
+    setInviteEmail('');
+    fetchData();
+  };
+
+  const changeRole = async (id: string, role: MembershipRole) => {
+    await fetch(`/api/memberships/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ role }),
+    });
+    fetchData();
+  };
+
+  const removeMember = async (id: string) => {
+    await fetch(`/api/memberships/${id}`, { method: 'DELETE' });
+    fetchData();
+  };
+
+  return (
+    <div className="p-4 space-y-8">
+      <div className="space-y-2">
+        <h2 className="text-lg font-semibold">Organization</h2>
+        <div className="flex gap-2 max-w-xl">
+          <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="Name" />
+          <Input value={slug} onChange={(e) => setSlug(e.target.value)} placeholder="Slug" />
+          <Button onClick={saveOrg}>Save</Button>
+        </div>
+        <Button variant="destructive" onClick={deleteOrg} className="mt-2">
+          Delete Organization
+        </Button>
+      </div>
+
+      <div className="space-y-2">
+        <h2 className="text-lg font-semibold">Members</h2>
+        <div className="flex gap-2 max-w-xl">
+          <Input
+            value={inviteEmail}
+            onChange={(e) => setInviteEmail(e.target.value)}
+            placeholder="Email"
+          />
+          <select
+            className="border rounded px-2 py-1"
+            value={inviteRole}
+            onChange={(e) => setInviteRole(e.target.value as MembershipRole)}
+          >
+            <option value={MembershipRole.REP}>REP</option>
+            <option value={MembershipRole.ADMIN}>ADMIN</option>
+            <option value={MembershipRole.OWNER}>OWNER</option>
+          </select>
+          <Button onClick={invite}>Invite</Button>
+        </div>
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr>
+              <th className="text-left p-2">Email</th>
+              <th className="p-2">Role</th>
+              <th className="p-2"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {members.map((m) => (
+              <tr key={m.id}>
+                <td className="p-2">{m.user.email}</td>
+                <td className="p-2">
+                  <select
+                    className="border rounded px-2 py-1"
+                    value={m.role}
+                    onChange={(e) => changeRole(m.id, e.target.value as MembershipRole)}
+                  >
+                    <option value={MembershipRole.REP}>REP</option>
+                    <option value={MembershipRole.ADMIN}>ADMIN</option>
+                    <option value={MembershipRole.OWNER}>OWNER</option>
+                  </select>
+                </td>
+                <td className="p-2 text-right">
+                  <Button variant="ghost" onClick={() => removeMember(m.id)}>
+                    Remove
+                  </Button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/app/app/settings/page.tsx
+++ b/src/app/app/settings/page.tsx
@@ -1,3 +1,17 @@
+import Link from "next/link";
+
 export default function SettingsPage() {
-  return <div className="p-4">Settings Page</div>;
+  return (
+    <div className="p-4 space-y-2">
+      <h1 className="text-xl font-bold">Settings</h1>
+      <ul className="list-disc pl-4">
+        <li>
+          <Link href="/app/settings/organization">Organization</Link>
+        </li>
+        <li>
+          <Link href="/app/settings/audit">Audit Logs</Link>
+        </li>
+      </ul>
+    </div>
+  );
 }

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -83,3 +83,13 @@ export async function sendEmail({
     console.log("Email send skipped");
   }
 }
+
+export async function sendInvitationEmail(email: string) {
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
+  const url = `${baseUrl}/register?email=${encodeURIComponent(email)}`;
+  await sendEmail({
+    to: email,
+    subject: "You're invited to join",
+    html: `<p>You have been invited to join an organization. <a href="${url}">Create your account</a>.</p>`,
+  });
+}

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { ActivityType, DealStatus } from "@prisma/client";
+import { ActivityType, DealStatus, MembershipRole } from "@prisma/client";
 
 /**
  * Central zod schemas used to validate and sanitize
@@ -63,5 +63,19 @@ export const stageSchema = z.object({
   pipelineId: z.string().cuid(),
   name: z.string().trim().min(1),
   order: z.number().int().nonnegative(),
+});
+
+export const organizationSchema = z.object({
+  name: z.string().trim().min(1).optional(),
+  slug: z.string().trim().min(1).optional(),
+});
+
+export const inviteSchema = z.object({
+  email: z.string().trim().email(),
+  role: z.nativeEnum(MembershipRole),
+});
+
+export const membershipSchema = z.object({
+  role: z.nativeEnum(MembershipRole),
 });
 


### PR DESCRIPTION
## Summary
- add organization and membership schemas
- implement APIs for organization and memberships
- support invites and settings UI

## Testing
- `npm test`
- `npm run lint` *(fails: next: not found; install 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c49079d4288330a233980b0bbf3dff