### PR TITLE
Add basic reporting pages with CSV exports

### DIFF
--- a/src/app/api/reports/cycle-time/route.ts
+++ b/src/app/api/reports/cycle-time/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+import { requireRole } from "@/lib/auth";
+import { MembershipRole } from "@prisma/client";
+import { handleApiError } from "@/lib/api";
+import { cycleTime } from "@/lib/reports";
+
+export async function GET(req: Request) {
+  try {
+    const { membership } = await requireRole(
+      MembershipRole.REP,
+      MembershipRole.ADMIN,
+      MembershipRole.OWNER
+    );
+    const { searchParams } = new URL(req.url);
+    const from = searchParams.get("from");
+    const to = searchParams.get("to");
+    const result = await cycleTime(
+      membership.organizationId,
+      from ? new Date(from) : undefined,
+      to ? new Date(to) : undefined
+    );
+    if (searchParams.get("format") === "csv") {
+      const csv = ["Deal,Owner,Cycle Time (days)"]
+        .concat(result.deals.map((d) => `${d.deal},${d.owner},${d.days}`))
+        .join("\n");
+      return new NextResponse(csv, {
+        headers: { "Content-Type": "text/csv" },
+      });
+    }
+    return NextResponse.json(result);
+  } catch (e) {
+    return handleApiError(e);
+  }
+}

--- a/src/app/api/reports/pipeline-value-by-stage/route.ts
+++ b/src/app/api/reports/pipeline-value-by-stage/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import { requireRole } from "@/lib/auth";
+import { MembershipRole } from "@prisma/client";
+import { handleApiError } from "@/lib/api";
+import { pipelineValueByStage } from "@/lib/reports";
+
+export async function GET(req: Request) {
+  try {
+    const { membership } = await requireRole(
+      MembershipRole.REP,
+      MembershipRole.ADMIN,
+      MembershipRole.OWNER
+    );
+    const data = await pipelineValueByStage(membership.organizationId);
+    const { searchParams } = new URL(req.url);
+    if (searchParams.get("format") === "csv") {
+      const csv = ["Stage,Value"]
+        .concat(data.map((d) => `${d.stage},${d.value}`))
+        .join("\n");
+      return new NextResponse(csv, {
+        headers: { "Content-Type": "text/csv" },
+      });
+    }
+    return NextResponse.json(data);
+  } catch (e) {
+    return handleApiError(e);
+  }
+}

--- a/src/app/api/reports/win-rate/route.ts
+++ b/src/app/api/reports/win-rate/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { requireRole } from "@/lib/auth";
+import { MembershipRole } from "@prisma/client";
+import { handleApiError } from "@/lib/api";
+import { winRateByOwner } from "@/lib/reports";
+
+export async function GET(req: Request) {
+  try {
+    const { membership } = await requireRole(
+      MembershipRole.REP,
+      MembershipRole.ADMIN,
+      MembershipRole.OWNER
+    );
+    const { searchParams } = new URL(req.url);
+    const from = searchParams.get("from");
+    const to = searchParams.get("to");
+    const data = await winRateByOwner(
+      membership.organizationId,
+      from ? new Date(from) : undefined,
+      to ? new Date(to) : undefined
+    );
+    if (searchParams.get("format") === "csv") {
+      const csv = ["Owner,Won,Lost,Win Rate"]
+        .concat(
+          data.map((d) => `${d.owner},${d.won},${d.lost},${d.winRate}`)
+        )
+        .join("\n");
+      return new NextResponse(csv, {
+        headers: { "Content-Type": "text/csv" },
+      });
+    }
+    return NextResponse.json(data);
+  } catch (e) {
+    return handleApiError(e);
+  }
+}

--- a/src/app/app/reports/page.tsx
+++ b/src/app/app/reports/page.tsx
@@ -1,3 +1,125 @@
-export default function ReportsPage() {
-  return <div className="p-4">Reports Page</div>;
+import { format } from "date-fns";
+import { requireRole } from "@/lib/auth";
+import { MembershipRole } from "@prisma/client";
+import {
+  pipelineValueByStage,
+  winRateByOwner,
+  cycleTime,
+} from "@/lib/reports";
+
+export default async function ReportsPage({
+  searchParams,
+}: {
+  searchParams?: { from?: string; to?: string };
+}) {
+  const { membership } = await requireRole(
+    MembershipRole.REP,
+    MembershipRole.ADMIN,
+    MembershipRole.OWNER
+  );
+  const from = searchParams?.from ? new Date(searchParams.from) : undefined;
+  const to = searchParams?.to ? new Date(searchParams.to) : undefined;
+  const pipeline = await pipelineValueByStage(membership.organizationId);
+  const winRates = await winRateByOwner(
+    membership.organizationId,
+    from,
+    to
+  );
+  const cycle = await cycleTime(membership.organizationId, from, to);
+  const fromStr = from ? format(from, "yyyy-MM-dd") : "";
+  const toStr = to ? format(to, "yyyy-MM-dd") : "";
+  return (
+    <div className="p-4 space-y-8">
+      <section>
+        <h2 className="text-xl font-semibold mb-2">
+          Pipeline Value by Stage
+        </h2>
+        <table className="min-w-full text-sm mb-2">
+          <thead>
+            <tr>
+              <th className="text-left p-1">Stage</th>
+              <th className="text-left p-1">Value</th>
+            </tr>
+          </thead>
+          <tbody>
+            {pipeline.map((p) => (
+              <tr key={p.stage}>
+                <td className="p-1">{p.stage}</td>
+                <td className="p-1">${p.value.toFixed(2)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <a
+          href="/api/reports/pipeline-value-by-stage?format=csv"
+          className="text-blue-600 underline"
+        >
+          Download CSV
+        </a>
+      </section>
+
+      <section>
+        <h2 className="text-xl font-semibold mb-2">Win Rate by Owner</h2>
+        <table className="min-w-full text-sm mb-2">
+          <thead>
+            <tr>
+              <th className="text-left p-1">Owner</th>
+              <th className="text-left p-1">Won</th>
+              <th className="text-left p-1">Lost</th>
+              <th className="text-left p-1">Win Rate</th>
+            </tr>
+          </thead>
+          <tbody>
+            {winRates.map((w) => (
+              <tr key={w.owner}>
+                <td className="p-1">{w.owner}</td>
+                <td className="p-1">{w.won}</td>
+                <td className="p-1">{w.lost}</td>
+                <td className="p-1">{w.winRate.toFixed(2)}%</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <a
+          href={`/api/reports/win-rate?from=${fromStr}&to=${toStr}&format=csv`}
+          className="text-blue-600 underline"
+        >
+          Download CSV
+        </a>
+      </section>
+
+      <section>
+        <h2 className="text-xl font-semibold mb-2">
+          Cycle Time (Open → Won)
+        </h2>
+        <p className="mb-2 text-sm">
+          Average: {cycle.average.toFixed(2)} days
+        </p>
+        <table className="min-w-full text-sm mb-2">
+          <thead>
+            <tr>
+              <th className="text-left p-1">Deal</th>
+              <th className="text-left p-1">Owner</th>
+              <th className="text-left p-1">Days</th>
+            </tr>
+          </thead>
+          <tbody>
+            {cycle.deals.map((d) => (
+              <tr key={d.deal}>
+                <td className="p-1">{d.deal}</td>
+                <td className="p-1">{d.owner}</td>
+                <td className="p-1">{d.days}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <a
+          href={`/api/reports/cycle-time?from=${fromStr}&to=${toStr}&format=csv`}
+          className="text-blue-600 underline"
+        >
+          Download CSV
+        </a>
+      </section>
+    </div>
+  );
 }

--- a/src/lib/reports.ts
+++ b/src/lib/reports.ts
@@ -1,0 +1,103 @@
+import { prisma } from "@/lib/prisma";
+import { DealStatus } from "@prisma/client";
+import { differenceInDays } from "date-fns";
+
+export async function pipelineValueByStage(organizationId: string) {
+  const stages = await prisma.stage.findMany({
+    where: { pipeline: { organizationId } },
+    include: {
+      deals: { where: { status: DealStatus.OPEN }, select: { valueCents: true } },
+    },
+    orderBy: { order: "asc" },
+  });
+  return stages.map((s) => ({
+    stage: s.name,
+    value: s.deals.reduce((sum, d) => sum + d.valueCents, 0) / 100,
+  }));
+}
+
+export async function winRateByOwner(
+  organizationId: string,
+  from?: Date,
+  to?: Date
+) {
+  const deals = await prisma.deal.findMany({
+    where: {
+      organizationId,
+      status: { in: [DealStatus.WON, DealStatus.LOST] },
+      ...(from || to
+        ? {
+            closeDate: {
+              ...(from ? { gte: from } : {}),
+              ...(to ? { lte: to } : {}),
+            },
+          }
+        : {}),
+    },
+    select: {
+      status: true,
+      owner: { select: { id: true, name: true } },
+    },
+  });
+
+  const map = new Map<
+    string,
+    { owner: string; won: number; lost: number }
+  >();
+  for (const deal of deals) {
+    const id = deal.owner.id;
+    const entry =
+      map.get(id) || {
+        owner: deal.owner.name ?? "Unknown",
+        won: 0,
+        lost: 0,
+      };
+    if (deal.status === DealStatus.WON) entry.won += 1;
+    else entry.lost += 1;
+    map.set(id, entry);
+  }
+  return Array.from(map.values()).map((e) => ({
+    owner: e.owner,
+    won: e.won,
+    lost: e.lost,
+    winRate: e.won + e.lost > 0 ? (e.won / (e.won + e.lost)) * 100 : 0,
+  }));
+}
+
+export async function cycleTime(
+  organizationId: string,
+  from?: Date,
+  to?: Date
+) {
+  const deals = await prisma.deal.findMany({
+    where: {
+      organizationId,
+      status: DealStatus.WON,
+      ...(from || to
+        ? {
+            closeDate: {
+              ...(from ? { gte: from } : {}),
+              ...(to ? { lte: to } : {}),
+            },
+          }
+        : {}),
+    },
+    select: {
+      title: true,
+      createdAt: true,
+      closeDate: true,
+      owner: { select: { name: true } },
+    },
+  });
+
+  const data = deals.map((d) => ({
+    deal: d.title,
+    owner: d.owner?.name ?? "Unknown",
+    days: d.closeDate ? differenceInDays(d.closeDate, d.createdAt) : 0,
+  }));
+  const average =
+    data.length > 0
+      ? data.reduce((sum, d) => sum + d.days, 0) / data.length
+      : 0;
+  return { deals: data, average };
+}


### PR DESCRIPTION
## Summary
- add reporting utilities to compute pipeline value, win rates, and cycle times
- expose API endpoints with optional CSV export
- implement reports page showing data and download links

## Testing
- `npm test`
- `npm run lint` *(fails: sh: 1: next: not found; npm install 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_68c4f75899a08330b2d8ce73253904c0