### PR TITLE
feat: add cached pagination for contacts and deals

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -162,6 +162,7 @@ model Contact {
 
   @@index([organizationId])
   @@index([email])
+  @@index([organizationId, lastName, firstName])
 }
 
 model Pipeline {
@@ -221,6 +222,7 @@ model Deal {
   @@index([ownerId])
   @@index([stageId])
   @@index([status])
+  @@index([organizationId, pipelineId, stageId])
 }
 
 model Activity {

--- a/src/app/app/deals/board/page.tsx
+++ b/src/app/app/deals/board/page.tsx
@@ -45,8 +45,11 @@ export default function DealsBoardPage() {
   useEffect(() => {
     if (!pipeline) return;
     const fetchDeals = async () => {
-      const res = await fetch(`/api/deals?pipelineId=${pipeline.id}`);
-      if (res.ok) setDeals(await res.json());
+      const res = await fetch(`/api/deals?pipelineId=${pipeline.id}&limit=500`);
+      if (res.ok) {
+        const json = await res.json();
+        setDeals(json.data);
+      }
     };
     fetchDeals();
   }, [pipeline]);


### PR DESCRIPTION
## Summary
- cache heavy list queries for contacts, deals, and pipelines
- paginate contact and deal listings with minimal column selection
- index common contact and deal query fields for faster lookups

## Testing
- `npx prisma generate` *(fails: 403 Forbidden - GET https://registry.npmjs.org/prisma)*
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4fbeaf7148330b1a9a8117f19dc60